### PR TITLE
Add default segment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,5 @@ end
 gem "minitest-ci", group: :test
 
 gem "timecop", "~> 0.9.1"
+
+gem "pry", "~> 0.12.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     builder (3.2.3)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     erubi (1.8.0)
@@ -80,6 +81,9 @@ GEM
     parser (2.6.3.0)
       ast (~> 2.4.0)
     pg (1.1.4)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     psych (3.1.0)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -146,6 +150,7 @@ DEPENDENCIES
   heya!
   minitest-ci
   pg
+  pry (~> 0.12.2)
   standard (~> 0.0.40)
   timecop (~> 0.9.1)
   yard (~> 0.9.19)

--- a/app/models/heya/campaign.rb
+++ b/app/models/heya/campaign.rb
@@ -8,12 +8,14 @@ module Heya
     delegate :sanitize_sql_array, to: ActiveRecord::Base
 
     def contacts(class_name)
-      contact_relation = class_name.constantize
-      contact_relation
+      klass = class_name.constantize
+      base_klass = klass.base_class
+
+      klass
         .joins(
           sanitize_sql_array([
-            "inner join heya_campaign_memberships on heya_campaign_memberships.contact_type = ? and heya_campaign_memberships.contact_id = #{contact_relation.table_name}.id and heya_campaign_memberships.campaign_id = ?",
-            class_name,
+            "inner join heya_campaign_memberships on heya_campaign_memberships.contact_type = ? and heya_campaign_memberships.contact_id = #{base_klass.table_name}.id and heya_campaign_memberships.campaign_id = ?",
+            base_klass.name,
             id,
           ])
         ).all

--- a/app/models/heya/message.rb
+++ b/app/models/heya/message.rb
@@ -9,11 +9,16 @@ module Heya
     delegate :contact_class, :action, :segment, :wait, :properties, to: :options
 
     def contact_class
-      @contact_class ||= options.contact_class.constantize
+      @contact_class ||= begin
+                           klass = options.contact_class
+                           klass.is_a?(String) ? klass.constantize : klass
+                         end
     end
 
-    def segment
-      @segment ||= contact_class.instance_exec(&options.segment)
+    def build_segment
+      contact_class
+        .build_default_segment
+        .instance_exec(&options.segment)
     end
 
     private

--- a/lib/heya/campaigns/queries.rb
+++ b/lib/heya/campaigns/queries.rb
@@ -16,7 +16,7 @@ module Heya
           .where(
             "heya_campaign_memberships.last_sent_at <= ?", wait_threshold
           )
-          .merge(message.segment)
+          .merge(message.build_segment)
       }
     end
   end

--- a/lib/heya/concerns/models/contact.rb
+++ b/lib/heya/concerns/models/contact.rb
@@ -4,12 +4,24 @@ module Heya
       module Contact
         extend ActiveSupport::Concern
 
+        included do
+          class_attribute :__heya_default_segment, instance_writer: true, instance_predicate: false, default: nil
+        end
+
         module ClassMethods
           # Segments are just scopes, added via the ::segment method (currently
           # just an alias, but I may store these in the future in order to
           # track membership).
           def segment(name, scope_lambda)
             scope(name, scope_lambda)
+          end
+
+          def default_segment(&block)
+            self.__heya_default_segment = block
+          end
+
+          def build_default_segment(relation = relation()) # rubocop:disable Style/MethodCallWithoutArgsParentheses
+            __heya_default_segment && relation.instance_exec(&__heya_default_segment) || relation
           end
         end
       end

--- a/test/dummy/db/migrate/20190613183430_create_contacts.rb
+++ b/test/dummy/db/migrate/20190613183430_create_contacts.rb
@@ -2,7 +2,7 @@ class CreateContacts < ActiveRecord::Migration[5.2]
   def change
     create_table :contacts do |t|
       t.string :email
-      t.jsonb :properties
+      t.jsonb :traits
 
       t.timestamps
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define(version: 2019_06_13_183430) do
 
   create_table "contacts", force: :cascade do |t|
     t.string "email"
-    t.jsonb "properties"
+    t.jsonb "traits"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/lib/heya/concerns/models/contact_test.rb
+++ b/test/lib/heya/concerns/models/contact_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+module Heya
+  module Models
+    module Concerns
+      class ContactTest < ActiveSupport::TestCase
+        include ActionMailer::TestHelper
+
+        class DefaultSegmentContact < Contact
+          default_segment { where(email: "one@example.com") }
+        end
+
+        test "has a default segment of all" do
+          assert_equal [contacts(:one), contacts(:two)], Contact.build_default_segment.limit(2).to_a
+        end
+
+        test "can override the default segment via lambda" do
+          assert_equal [contacts(:one)], (DefaultSegmentContact.build_default_segment.limit(2).to_a.map { |m| m.becomes(Contact) })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds `default_segment` to the contact DSL (in addition to `segment`). Together, these work like `default_scope` and `scope`, but they're specific to Heya contacts.

I added this to support 3rd-party unsubscribe systems:

https://github.com/honeybadger-io/heya-app/pull/1

In the future I'd like to build a double-opt-in subscribe/unsubscribe system for Heya. :)

---
For future reference: I made the `default_segment` method pretty dumb initially. It can only be called once (not multiple times, like `default_scope` in Rails), and it doesn't support more complex default segments via a method (like Rails does). All of that could be added; the way Rails does it is [here](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/scoping/default.rb).