### PR TITLE
Add a base segment to campaigns

### DIFF
--- a/app/models/heya/message.rb
+++ b/app/models/heya/message.rb
@@ -18,6 +18,7 @@ module Heya
     def build_segment
       contact_class
         .build_default_segment
+        .instance_exec(&campaign.klass.segment)
         .instance_exec(&options.segment)
     end
 

--- a/lib/heya/campaigns/base.rb
+++ b/lib/heya/campaigns/base.rb
@@ -6,7 +6,7 @@ module Heya
     # Multiple actions are supported; the default is email.
     class Base
       class << self
-        class_attribute :defaults
+        class_attribute :defaults, :__segment
 
         self.defaults = {
           contact_class: "User",
@@ -14,6 +14,8 @@ module Heya
           segment: -> { all },
           wait: 2.days,
         }.freeze
+
+        self.__segment = -> { all }
 
         def campaign
           @campaign ||= ::Heya::Campaign.where(name: name).first_or_create!.tap do |campaign|
@@ -41,6 +43,14 @@ module Heya
           options[:properties] = props.reject { |k, _| defaults.key?(k) }.stringify_keys
 
           steps[name] = OpenStruct.new(defaults.merge(options))
+        end
+
+        def segment(&block)
+          if block_given?
+            self.__segment = block
+          end
+
+          self.__segment
         end
 
         delegate :add, :remove, to: :campaign

--- a/test/lib/heya/campaigns/base_test.rb
+++ b/test/lib/heya/campaigns/base_test.rb
@@ -16,6 +16,20 @@ module Heya
         assert_not_equal Base.defaults, klass.defaults
       end
 
+      test "it sets class segment" do
+        assert_kind_of Proc, Base.segment
+      end
+
+      test "it allows subclasses to change segment" do
+        block = -> { where(id: 1) }
+        klass = Class.new(Base) {
+          segment(&block)
+        }
+
+        assert_equal block, klass.segment
+        assert_not_equal Base.segment, klass.segment
+      end
+
       test "it lazily creates a new campaign model" do
         klass = assert_no_difference("Heya::Campaign.count") {
           Class.new(Base) {


### PR DESCRIPTION
This is a nice way to drill down on who should receive the emails in
your campaign. For example:

```ruby
class SignupFirstRunCampaign < Heya::Campaigns::Base
  default wait: 1.days

  segment { signups }

  step :welcome, wait: 0.days,
    subject: "Welcome to Honeybadger! 👋"

  step :install_1, segment: -> { where.not(id: installed) },
    subject: "How many Honeybadgers does it take?"
end
```

When added to this campaign, contacts who match the "signups" segment
will receive messages. Step-level segments are merged, so that the
"install_1" step will be sent to signups who haven't installed the code
yet. If a contact ever leaves the signups segment while the campaign is
in progress, they will naturally leave the campaign.