### PR TITLE
Campaign Priority

### DIFF
--- a/db/migrate/20190607005755_create_heya_campaigns.rb
+++ b/db/migrate/20190607005755_create_heya_campaigns.rb
@@ -2,6 +2,7 @@ class CreateHeyaCampaigns < ActiveRecord::Migration[5.2]
   def change
     create_table :heya_campaigns do |t|
       t.string :name
+      t.integer :position, null: false
 
       t.timestamps
     end

--- a/lib/heya.rb
+++ b/lib/heya.rb
@@ -6,4 +6,27 @@ require "heya/campaigns/scheduler"
 require "heya/concerns/models/contact"
 
 module Heya
+  extend self
+
+  def configure
+    yield(config)
+    update
+    config
+  end
+
+  def config
+    @config ||= OpenStruct.new(
+      priority: [],
+    )
+  end
+
+  def update
+    Campaigns::Base.subclasses.each(&:load_model)
+    ActiveRecord::Base.transaction do
+      Campaign.update_all(position: -1)
+      config.priority.reverse_each.with_index do |campaign, index|
+        campaign.model.update_attribute(:position, index)
+      end
+    end
+  end
 end

--- a/lib/heya/campaigns/base.rb
+++ b/lib/heya/campaigns/base.rb
@@ -53,7 +53,7 @@ module Heya
         end
 
         def model
-          @model ||= ::Heya::Campaign.where(name: name).first_or_create!.tap do |campaign|
+          @model ||= ::Heya::Campaign.where(name: name, position: -1).first_or_create!.tap do |campaign|
             steps.each.with_index do |name_opts, i|
               name, opts = name_opts
               campaign.messages.where(name: name).first_or_create! { |message|

--- a/lib/heya/campaigns/queries.rb
+++ b/lib/heya/campaigns/queries.rb
@@ -3,15 +3,27 @@ module Heya
     module Queries
       NEXT_MESSAGE_SUBQUERY = <<~SQL.freeze
         (SELECT m.id FROM heya_messages AS m
-          WHERE m.campaign_id = :campaign_id
-          AND m.position > coalesce((SELECT m.position FROM heya_message_receipts AS r
-            INNER JOIN heya_messages AS m ON m.id = r.message_id AND m.campaign_id = :campaign_id
-            WHERE r.contact_type = heya_campaign_memberships.contact_type AND r.contact_id = heya_campaign_memberships.contact_id
-            ORDER BY m.position DESC
-            LIMIT 1), -1)
-          ORDER BY m.position ASC
-          LIMIT 1
+         WHERE m.campaign_id = :campaign_id
+           AND m.position > coalesce((SELECT m.position FROM heya_message_receipts AS r
+             INNER JOIN heya_messages AS m ON m.id = r.message_id AND m.campaign_id = :campaign_id
+             WHERE r.contact_type = heya_campaign_memberships.contact_type
+               AND r.contact_id = heya_campaign_memberships.contact_id
+             ORDER BY m.position DESC
+             LIMIT 1), -1)
+           ORDER BY m.position ASC
+           LIMIT 1
         ) = :message_id
+      SQL
+
+      CAMPAIGN_SUBQUERY = <<~SQL.freeze
+        (SELECT memberships.campaign_id FROM heya_campaign_memberships AS memberships
+         INNER JOIN heya_campaigns AS campaigns
+           ON campaigns.id = memberships.campaign_id
+         WHERE memberships.contact_type = heya_campaign_memberships.contact_type
+           AND memberships.contact_id = heya_campaign_memberships.contact_id
+         ORDER BY campaigns.position DESC, memberships.created_at DESC
+         LIMIT 1
+        ) = :campaign_id
       SQL
 
       # Given a campaign and a message, {Queries::ContactsForMessage} returns
@@ -30,6 +42,9 @@ module Heya
           .where(NEXT_MESSAGE_SUBQUERY, {
             campaign_id: campaign.id,
             message_id: message.id,
+          })
+          .where(CAMPAIGN_SUBQUERY, {
+            campaign_id: campaign.id,
           })
           .where(
             "heya_campaign_memberships.last_sent_at <= ?", wait_threshold

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2019_06_13_183430) do
 
   create_table "heya_campaigns", force: :cascade do |t|
     t.string "name"
+    t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/heya/campaigns.yml
+++ b/test/fixtures/heya/campaigns.yml
@@ -6,3 +6,4 @@
 #
 one:
   name: FirstCampaign
+  position: -1


### PR DESCRIPTION
This adds a default lock around campaigns so that only one will send at a time, based on a configurable priority. If there is no priority, it will send the most recently added campaign first. In the future, I would add the concept of "concurrent" campaigns, which would allow you to skip the lock for certain campaigns/contacts.

This would allow us to add users to lifecycle campaigns without worrying about them conflicting. Here's an example:

```ruby
Heya.configure do |config|
  config.priority = [
    TrialToPaidConversionCampaign,
    FirstRunOnboardingCampaign,
    LongTermOnboardingCampaign,
  ]
end

# When a user signs up:
FirstRunOnboardingCampaign.add(user)
LongTermOnboardingCampaign.add(user)

# When the `trial_will_end.subscription.hb` event occurs:
TrialToPaidConversionCampaign.add(user, restart: true)
```

What do you think of this idea, @stympy?