### PR TITLE
Add campaign priority

### DIFF
--- a/lib/heya/campaigns/scheduler.rb
+++ b/lib/heya/campaigns/scheduler.rb
@@ -34,7 +34,7 @@ module Heya
 
           if Heya.in_segments?(user, user.class.__heya_default_segment, campaign.segment, step.segment)
             now = Time.now.utc
-            CampaignMembership.where(user: user, campaign_gid: campaign.gid).update_all(last_sent_at: now)
+            CampaignMembership.where(user: user).update_all(last_sent_at: now)
             CampaignReceipt.create!(user: user, step_gid: step.gid, sent_at: now)
             step.action.call(user: user, step: step)
           else

--- a/lib/heya/config.rb
+++ b/lib/heya/config.rb
@@ -5,6 +5,7 @@ module Heya
     def initialize(**opts)
       super({
         user_type: "User",
+        priority: [],
       }.merge(opts))
     end
   end


### PR DESCRIPTION
Closes #18

This adds a default lock around campaigns so that only one will send at a time, based on a configurable priority. If there is no priority, it will send the most recently added campaign first. In the future, I would add the concept of "concurrent" campaigns, which would allow you to skip the lock for certain campaigns/users.

This would allow us to add users to lifecycle campaigns without worrying about them conflicting. Here's an example:

```ruby
Heya.configure do |config|
  config.priority = [
    TrialToPaidConversionCampaign,
    FirstRunOnboardingCampaign,
    LongTermOnboardingCampaign,
  ]
end

# When a user signs up:
FirstRunOnboardingCampaign.add(user)
LongTermOnboardingCampaign.add(user)

# When the `trial_will_end.subscription.hb` event occurs:
TrialToPaidConversionCampaign.add(user, restart: true)
```

Since the `TrialToPaidConversionCampaign` is always first priority, whenever a trial period is ending, the user's other campaigns are paused and the `TrialToPaidConversionCampaign` emails are sent. Once complete, the user is removed from `TrialToPaidConversionCampaign` and their next-highest priority campaign resumes.