### PR TITLE
Block actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ end
 ```
 
 #### Steps
-The `step` command defines a new step in the sequence. When you add a user to the campaign, Heya completes each step in the order that it appears.
+The `step` method defines a new step in the sequence. When you add a user to the campaign, Heya completes each step in the order that it appears.
 
 The default time to wait between steps is *two days*, calculated from the time the user completed the previous step (or the time the user entered the campaign, in the case of the first step).
 
@@ -187,6 +187,27 @@ class OnboardingCampaign < Heya::Campaigns::Base
     subject: "Welcome to my app!"
 end
 ```
+
+### Custom Actions
+
+You can override the default step behavior to perform custom actions by passing
+a block to the `step` method:
+
+```ruby
+class OnboardingCampaign < Heya::Campaigns::Base
+  step :first_email,
+    subject: "You're about to receive a txt"
+
+  step :sms do |user|
+    SMSJob.perform_later(to: user.cell, body: "Hi, #{user.first_name}!")
+  end
+
+  step :second_email,
+    subject: "Did you get it?"
+end
+```
+
+Step blocks receive two optional arguments: `user` and `step`.
 
 ### Adding users to campaigns
 Heya leaves *when* to add users to campaigns completely up to you; here's how to add a user to a campaign from anywhere in your app:

--- a/app/mailers/heya/application_mailer.rb
+++ b/app/mailers/heya/application_mailer.rb
@@ -1,6 +1,4 @@
 module Heya
   class ApplicationMailer < ActionMailer::Base
-    default from: "from@example.com"
-    layout "mailer"
   end
 end

--- a/app/mailers/heya/campaign_mailer.rb
+++ b/app/mailers/heya/campaign_mailer.rb
@@ -1,20 +1,22 @@
-class Heya::CampaignMailer < ApplicationMailer
-  layout "heya/campaign_mailer"
+module Heya
+  class CampaignMailer < ApplicationMailer
+    layout "heya/campaign_mailer"
 
-  def build
-    user = params.fetch(:user)
+    def build
+      user = params.fetch(:user)
 
-    step = params.fetch(:step)
-    campaign = step.campaign
+      step = params.fetch(:step)
+      campaign = step.campaign
 
-    instance_variable_set(:"@#{user.model_name.element}", user)
+      instance_variable_set(:"@#{user.model_name.element}", user)
 
-    mail(
-      from: step.from || Heya.config.from,
-      to: user.email,
-      subject: step.properties.fetch("subject"),
-      template_path: "heya/campaign_mailer/#{campaign.name.underscore}",
-      template_name: step.name.underscore
-    )
+      mail(
+        from: step.from || Heya.config.from,
+        to: user.email,
+        subject: step.properties.fetch("subject"),
+        template_path: "heya/campaign_mailer/#{campaign.name.underscore}",
+        template_name: step.name.underscore
+      )
+    end
   end
 end

--- a/lib/generators/heya/install/templates/initializer.rb.tt
+++ b/lib/generators/heya/install/templates/initializer.rb.tt
@@ -3,7 +3,7 @@ Heya.configure do |config|
   config.user_type = "User"
 
   # The default from address to use when sending campaigns.
-  config.from = "user@example.com"
+  config.from = "from@example.com"
 
   # Campaign priority. When a user is added to multiple campaigns, they are
   # sent in this order. Campaigns are sent in the order that the users were

--- a/lib/heya/campaigns/actions.rb
+++ b/lib/heya/campaigns/actions.rb
@@ -5,5 +5,27 @@ module Heya
         .with(user: user, step: step)
         .build
     end
+
+    class Block
+      class Execution; end
+
+      def self.build(block)
+        ->(user:, step:) {
+          new(user, step, block)
+        }
+      end
+
+      def initialize(user, step, block)
+        @user = user
+        @step = step
+        @block = block
+        @execution = Execution.new
+      end
+
+      def deliver_now
+        @execution.instance_exec(@user, @step, &@block)
+      end
+      alias deliver_later deliver_now
+    end
   end
 end

--- a/lib/heya/campaigns/base.rb
+++ b/lib/heya/campaigns/base.rb
@@ -108,20 +108,21 @@ module Heya
           __segment
         end
 
-        def step(name, **props)
+        def step(name, **props, &block)
           options = props.select { |k, _| __defaults.key?(k) }
           options[:properties] = props.reject { |k, _| __defaults.key?(k) }.stringify_keys
           options[:id] = "#{self.name}/#{name}"
           options[:name] = name.to_s
           options[:position] = steps.size
           options[:campaign] = instance
+          options[:action] = Actions::Block.build(block) if block_given?
 
           step = Step.new(__defaults.merge(options))
           method_name = :"#{step.name.underscore}"
           raise "Invalid step name: #{step.name}\n  Step names must not conflict with method names on Heya::Campaigns::Base" if respond_to?(method_name)
 
           define_singleton_method method_name do |user|
-            step.action.call(step: step, user: user)
+            step.action.call(user: user, step: step)
           end
           steps << step
 

--- a/test/lib/heya/campaigns/actions_test.rb
+++ b/test/lib/heya/campaigns/actions_test.rb
@@ -13,6 +13,42 @@ module Heya
           Actions::Email.call(user: contact, step: step).deliver_later
         end
       end
+
+      test "block actions respond to ActionMailer::MessageDelivery API subset" do
+        mock = MiniTest::Mock.new
+        block = Proc.new { |user, step|
+          mock.call(user, step)
+        }
+        action = Actions::Block.build(block)
+
+        mock.expect(:call, nil, [:user, :step])
+        mock.expect(:call, nil, [:user, :step])
+
+        action.call(user: :user, step: :step).deliver_now
+        action.call(user: :user, step: :step).deliver_later
+
+        assert_mock mock
+      end
+
+      test "block actions can be called with one argument" do
+        mock = MiniTest::Mock.new
+        block = Proc.new { |u| mock.call(u) }
+        action = Actions::Block.build(block)
+
+        mock.expect(:call, nil, [:user])
+        action.call(user: :user, step: :step).deliver_now
+        assert_mock mock
+      end
+
+      test "block actions can be called with no arguments" do
+        mock = MiniTest::Mock.new
+        block = Proc.new { mock.call }
+        action = Actions::Block.build(block)
+
+        mock.expect(:call, nil, [])
+        action.call(user: :user, step: :step).deliver_now
+        assert_mock mock
+      end
     end
   end
 end

--- a/test/lib/heya/campaigns/base_test.rb
+++ b/test/lib/heya/campaigns/base_test.rb
@@ -197,6 +197,20 @@ module Heya
           }
         end
       end
+
+      test "executes block actions" do
+        mock = MiniTest::Mock.new
+        campaign = Class.new(Base) {
+          step :expected_name do |user, step|
+            mock.call(user, step.name)
+          end
+        }
+        user = Object.new
+
+        mock.expect(:call, nil, [user, "expected_name"])
+
+        campaign.expected_name(user).deliver_now
+      end
     end
   end
 end


### PR DESCRIPTION
When steps have a block, build an action which always calls the block
synchronously (no background processing); the block is responsible for
delaying execution if necessary.

This adds an easy API for creating custom actions:

```ruby
class OnboardingCampaign < Heya::Campaigns::Base
  step :first_email,
    subject: "You're about to receive a txt msg"

  step :sms do |user|
    SMSJob.perform_later(to: user.cell, body: "Hi, #{user.first_name}!")
  end

  step :second_email,
    subject: "Did you get it?"
end
```