### PR TITLE
Refactor Actions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ class OnboardingCampaign < Heya::Campaigns::Base
     subject: "You're about to receive a txt"
 
   step :sms do |user|
-    SMSJob.perform_later(to: user.cell, body: "Hi, #{user.first_name}!")
+    SMS.new(to: user.cell, body: "Hi, #{user.first_name}!").deliver
   end
 
   step :second_email,
@@ -207,7 +207,8 @@ class OnboardingCampaign < Heya::Campaigns::Base
 end
 ```
 
-Step blocks receive two optional arguments: `user` and `step`.
+Step blocks receive two optional arguments: `user` and `step`, and are processed
+in a background job alongside other actions.
 
 ### Adding users to campaigns
 Heya leaves *when* to add users to campaigns completely up to you; here's how to add a user to a campaign from anywhere in your app:

--- a/heya.gemspec
+++ b/heya.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/honeybadger-io/heya"
   spec.summary = "Heya 👋"
   spec.description = "Heya 👋"
-  spec.license     = "Prosperity Public License"
+  spec.license = "Prosperity Public License"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.

--- a/lib/heya.rb
+++ b/lib/heya.rb
@@ -1,10 +1,12 @@
 require "heya/engine"
 require "heya/config"
+require "heya/campaigns/action"
 require "heya/campaigns/actions"
 require "heya/campaigns/base"
 require "heya/campaigns/queries"
 require "heya/campaigns/scheduler"
 require "heya/campaigns/step"
+require "heya/campaigns/step_action_job"
 require "heya/concerns/models/user"
 
 module Heya

--- a/lib/heya/campaigns/action.rb
+++ b/lib/heya/campaigns/action.rb
@@ -1,0 +1,25 @@
+module Heya
+  module Campaigns
+    class Action
+      def initialize(user:, step:)
+        @user, @step = user, step
+      end
+
+      attr_reader :user, :step
+
+      def build
+        raise NotImplementedError, "Please implement #build on subclass of Heya::Campaigns::Action."
+      end
+
+      def deliver_now
+        build.deliver
+      end
+
+      def deliver_later
+        StepActionJob
+          .set(queue: step.queue || Heya.config.queue)
+          .perform_later(step.campaign.class.name, user, step)
+      end
+    end
+  end
+end

--- a/lib/heya/campaigns/scheduler.rb
+++ b/lib/heya/campaigns/scheduler.rb
@@ -34,7 +34,7 @@ module Heya
             now = Time.now.utc
             Queries::CampaignMembershipsForUpdate.call(campaign, user).update_all(last_sent_at: now)
             CampaignReceipt.create!(user: user, step_gid: step.gid, sent_at: now)
-            step.action.call(user: user, step: step).deliver_later
+            step.action.new(user: user, step: step).deliver_later
           else
             CampaignReceipt.create!(user: user, step_gid: step.gid)
           end

--- a/lib/heya/campaigns/step_action_job.rb
+++ b/lib/heya/campaigns/step_action_job.rb
@@ -1,0 +1,32 @@
+module Heya
+  module Campaigns
+    class StepActionJob < ActiveJob::Base
+      queue_as { Heya.config.queue }
+
+      rescue_from StandardError, with: :handle_exception_with_campaign_class
+
+      def perform(_campaign, user, step)
+        step.action.new(user, step).deliver_now
+      end
+
+      private
+
+      # From ActionMailer: "deserialize" the mailer class name by hand in case
+      # another argument (like a Global ID reference) raised
+      # DeserializationError.
+      def campaign_class
+        if (campaign = Array(@serialized_arguments).first || Array(arguments).first)
+          campaign.constantize
+        end
+      end
+
+      def handle_exception_with_campaign_class(exception)
+        if (klass = campaign_class)
+          klass.handle_exception(exception)
+        else
+          raise exception
+        end
+      end
+    end
+  end
+end

--- a/lib/heya/config.rb
+++ b/lib/heya/config.rb
@@ -7,6 +7,7 @@ module Heya
         user_type: "User",
         priority: [],
         from: nil,
+        queue: "heya",
       }.merge(opts))
     end
   end

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
@@ -84,9 +84,9 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
   # Do not dump schema after migrations.

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.

--- a/test/dummy/config/puma.rb
+++ b/test/dummy/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/test/lib/heya/campaigns/actions_test.rb
+++ b/test/lib/heya/campaigns/actions_test.rb
@@ -9,44 +9,49 @@ module Heya
         contact = contacts(:one)
         step = FirstCampaign.steps.first
 
-        assert_enqueued_email_with CampaignMailer, :build, args: {user: contact, step: step} do
-          Actions::Email.call(user: contact, step: step).deliver_later
+        assert_emails 1 do
+          Actions::Email.new(user: contact, step: step).deliver_now
         end
       end
 
-      test "block actions respond to ActionMailer::MessageDelivery API subset" do
-        mock = MiniTest::Mock.new
-        block = Proc.new { |user, step|
-          mock.call(user, step)
-        }
-        action = Actions::Block.build(block)
+      test "it queues a default job for step" do
+        contact = contacts(:one)
+        step = FirstCampaign.steps.first
 
-        mock.expect(:call, nil, [:user, :step])
-        mock.expect(:call, nil, [:user, :step])
+        assert_enqueued_with(job: StepActionJob, queue: "heya") do
+          Actions::Email.new(user: contact, step: step).deliver_later
+        end
+      end
 
-        action.call(user: :user, step: :step).deliver_now
-        action.call(user: :user, step: :step).deliver_later
-
-        assert_mock mock
+      test "it queues a custom job for step" do
+        contact = contacts(:one)
+        step = FirstCampaign.steps.first
+        step.stub(:queue, "expected") do
+          assert_enqueued_with(job: StepActionJob, queue: "expected") do
+            Actions::Email.new(user: contact, step: step).deliver_later
+          end
+        end
       end
 
       test "block actions can be called with one argument" do
         mock = MiniTest::Mock.new
-        block = Proc.new { |u| mock.call(u) }
-        action = Actions::Block.build(block)
+        block = proc { |u| mock.call(u) }
+        step = OpenStruct.new(properties: {block: block})
+        action = Actions::Block.new(user: :user, step: step)
 
         mock.expect(:call, nil, [:user])
-        action.call(user: :user, step: :step).deliver_now
+        action.deliver_now
         assert_mock mock
       end
 
       test "block actions can be called with no arguments" do
         mock = MiniTest::Mock.new
-        block = Proc.new { mock.call }
-        action = Actions::Block.build(block)
+        block = proc { mock.call }
+        step = OpenStruct.new(properties: {block: block})
+        action = Actions::Block.new(user: :user, step: step)
 
         mock.expect(:call, nil, [])
-        action.call(user: :user, step: :step).deliver_now
+        action.deliver_now
         assert_mock mock
       end
     end

--- a/test/lib/heya/campaigns/base_test.rb
+++ b/test/lib/heya/campaigns/base_test.rb
@@ -87,7 +87,7 @@ module Heya
         }
         contact = contacts(:one)
 
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.first,
         }])
@@ -179,15 +179,16 @@ module Heya
       end
 
       test "generates an action method for each step" do
-        mock = MiniTest::Mock.new
-        campaign = Class.new(Base) {
-          step :expected_name, action: ->(user:, step:) { mock.call(user, step.name) }
+        action = Class.new(Action) {
+          def build
+            :expected
+          end
         }
-        user = Object.new
+        campaign = Class.new(Base) {
+          step :expected_name, action: action
+        }
 
-        mock.expect(:call, nil, [user, "expected_name"])
-
-        campaign.expected_name(user)
+        assert_equal :expected, campaign.expected_name(:user)
       end
 
       test "doesn't allow existing method names as step names" do
@@ -209,7 +210,7 @@ module Heya
 
         mock.expect(:call, nil, [user, "expected_name"])
 
-        campaign.expected_name(user).deliver_now
+        campaign.expected_name(user).deliver
       end
     end
   end

--- a/test/lib/heya/campaigns/scheduler_test.rb
+++ b/test/lib/heya/campaigns/scheduler_test.rb
@@ -38,7 +38,7 @@ module Heya
         assert_mock action
 
         Timecop.travel(6.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.first,
         }])
@@ -50,7 +50,7 @@ module Heya
         assert_mock action
 
         Timecop.travel(1.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.second,
         }])
@@ -62,7 +62,7 @@ module Heya
         assert_mock action
 
         Timecop.travel(1.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.third,
         }])
@@ -95,7 +95,7 @@ module Heya
         contact.update_attribute(:traits, {foo: "bar"})
         campaign.add(contact, send_now: false)
 
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.first,
         }])
@@ -117,7 +117,7 @@ module Heya
         contact.update_attribute(:traits, {bar: "baz"})
         campaign.add(contact, send_now: false)
 
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.first,
         }])
@@ -129,7 +129,7 @@ module Heya
         assert_mock action
 
         Timecop.travel(1.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.third,
         }])
@@ -168,7 +168,7 @@ module Heya
         contact.update_attribute(:traits, {foo: "bar"})
         campaign.add(contact, send_now: false)
 
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.first,
         }])
@@ -205,7 +205,7 @@ module Heya
         contact.update_attribute(:traits, {foo: "foo"})
         campaign.add(contact, send_now: false)
 
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.first,
         }])
@@ -243,7 +243,7 @@ module Heya
         contact = contacts(:one)
         campaign.add(contact, send_now: false)
 
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign.steps.first,
         }])
@@ -299,7 +299,7 @@ module Heya
         assert_mock action
 
         Timecop.travel(6.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign1.steps.first,
         }])
@@ -311,7 +311,7 @@ module Heya
         assert_mock action
 
         Timecop.travel(1.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign2.steps.first,
         }])
@@ -323,7 +323,7 @@ module Heya
         assert_mock action
 
         Timecop.travel(1.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign3.steps.first,
         }])
@@ -361,11 +361,11 @@ module Heya
         assert_mock action
 
         Timecop.travel(3.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign1.steps.first,
         }])
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign2.steps.first,
         }])
@@ -377,7 +377,7 @@ module Heya
         assert_mock action
 
         Timecop.travel(1.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign1.steps.second,
         }])
@@ -385,11 +385,11 @@ module Heya
         assert_mock action
 
         Timecop.travel(1.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign1.steps.third,
         }])
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign2.steps.second,
         }])
@@ -401,7 +401,7 @@ module Heya
         assert_mock action
 
         Timecop.travel(1.days.from_now)
-        action.expect(:call, NullMail, [{
+        action.expect(:new, NullMail, [{
           user: contact,
           step: campaign3.steps.first,
         }])


### PR DESCRIPTION
This allows companion gems (I have one idea I'm working on) to define actions like this:

```ruby
module Heya
  module Campaigns
    module Actions
      class Messenger < Action
        def build
          inbox = step.properties.fetch("inbox", :default)
          body = step.properties.fetch("body")
          Heya::Messenger.get_inbox(user, inbox).build(
            from: step.from,
            body: body
          )
        end
      end
    end
  end
end
```

The object built by `Action#build` must respond to a method `#deliver`
(similar to ActionMailer). This allows Heya to build the message object
and give it to the user for unit testing, but deliver it in the
background via ActiveJob (which now happens on a dedicated queue).

The idea is that different actions build different messages, but the
messages are all tested and processed the same.

A side-effect of this change is that block actions are processed in the
background instead of in the scheduler (meaning you don't have to worry
about scheduling your own jobs). I decided that it's simpler to treat
all actions (including blocks) as the same, for now. I may rethink block
actions in the future.