### PR TITLE
Drop default_segment in favor of ApplicationCampaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ end
 ```
 
 #### Segmenting all campaigns
-Heya campaigns inherit options form parent campaigns. For example, to make sure
+Heya campaigns inherit options from parent campaigns. For example, to make sure
 unsubscribed users never receive an email from Heya, create a `segment` in the
 `ApplicationCampaign`, and then have all other campaigns inherit from it:
 

--- a/lib/generators/heya/campaign/campaign_generator.rb
+++ b/lib/generators/heya/campaign/campaign_generator.rb
@@ -4,6 +4,7 @@ class Heya::CampaignGenerator < Rails::Generators::NamedBase
   argument :steps, type: :array, default: []
 
   def copy_campaign_template
+    template "application_campaign.rb", "app/campaigns/application_campaign.rb"
     template "campaign.rb", "app/campaigns/#{file_name.underscore}_campaign.rb"
   end
 

--- a/lib/generators/heya/campaign/templates/application_campaign.rb.tt
+++ b/lib/generators/heya/campaign/templates/application_campaign.rb.tt
@@ -1,0 +1,3 @@
+class ApplicationCampaign < Heya::Campaigns::Base
+  default from: "from@example.com"
+end

--- a/lib/generators/heya/campaign/templates/campaign.rb.tt
+++ b/lib/generators/heya/campaign/templates/campaign.rb.tt
@@ -1,4 +1,4 @@
-class <%= file_name.camelcase %>Campaign < Heya::Campaigns::Base
+class <%= file_name.camelcase %>Campaign < ApplicationCampaign
 <% steps.each do |step| %>
   step :<%= step.underscore.to_sym %>,
     subject: "<%= step.humanize %> Message"

--- a/lib/heya/campaigns/base.rb
+++ b/lib/heya/campaigns/base.rb
@@ -19,7 +19,7 @@ module Heya
       end
 
       def add(user, restart: false, concurrent: false, send_now: true)
-        return false unless Heya.in_segments?(user, user.class.__heya_default_segment, *__segments)
+        return false unless Heya.in_segments?(user, *__segments)
 
         restart && CampaignReceipt
           .where(user: user, step_gid: steps.map(&:gid))

--- a/lib/heya/campaigns/step.rb
+++ b/lib/heya/campaigns/step.rb
@@ -15,7 +15,7 @@ module Heya
       end
 
       def in_segment?(user)
-        Heya.in_segments?(user, user.class.__heya_default_segment, *campaign.__segments, segment)
+        Heya.in_segments?(user, *campaign.__segments, segment)
       end
     end
   end

--- a/lib/heya/concerns/models/user.rb
+++ b/lib/heya/concerns/models/user.rb
@@ -5,15 +5,8 @@ module Heya
         extend ActiveSupport::Concern
 
         included do
-          class_attribute :__heya_default_segment, instance_writer: true, instance_predicate: false, default: nil
           has_many :heya_campaign_memberships, class_name: "Heya::CampaignMembership", as: :user, dependent: :destroy
           has_many :heya_campaign_receipts, class_name: "Heya::CampaignReceipt", as: :user, dependent: :destroy
-        end
-
-        module ClassMethods
-          def default_segment(&block)
-            self.__heya_default_segment = block
-          end
         end
       end
     end

--- a/test/lib/heya/campaigns/base_test.rb
+++ b/test/lib/heya/campaigns/base_test.rb
@@ -154,22 +154,6 @@ module Heya
         assert_mock action
       end
 
-      test "#add requires default_segment to match" do
-        class TestContact < Contact
-          default_segment { |u| u.traits["foo"] == "bar" }
-        end
-        campaign = create_test_campaign {
-          user_type TestContact
-        }
-        contact = contacts(:one).becomes(TestContact)
-
-        refute campaign.add(contact)
-
-        contact.update_attribute(:traits, {foo: "bar"})
-
-        assert campaign.add(contact)
-      end
-
       test "#add requires campaign segment to match" do
         campaign = create_test_campaign {
           user_type "Contact"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,8 +56,8 @@ module Heya::Campaigns
 end
 
 class ActiveSupport::TestCase
-  def create_test_campaign(name = "TestCampaign", &block)
-    klass = Class.new(Heya::Campaigns::Base) {
+  def create_test_campaign(name: "TestCampaign", parent: Heya::Campaigns::Base, &block)
+    klass = Class.new(parent) {
       class << self
         attr_accessor :name
       end


### PR DESCRIPTION
Now that campaigns can inherit from each other, parent segments can act
as "default segments" for different campaigns. I never really loved the
idea of `default_segment` (about as much as I love `default_scope`).
This solves the same problem with a more attractive/versatile
implementation imo.

This is also a step towards not requiring a User concern (hopefully). See #42.

Edit: oh yeah, here's a tl;dr. I prefer this:

```ruby
# app/campaigns/application_campaign.rb
class ApplicationCampaign < Heya::Campaigns::Base
  default from: "from@example.com"
  segment :subscribed?
end

# app/campaigns/onboarding_campaign.rb
class OnboardingCampaign < ApplicationCampaign
  # steps...
end
```

instead of this:

```ruby
# app/models/user.rb
class User < ApplicationModel
  include Heya::Concerns::Models::User
  default_segment :subscribed?
end

# app/campaigns/onboarding_campaign.rb
class OnboardingCampaign < Heya::Campaigns::Base
  # steps...
end
```