### PR TITLE
Add optional wait argument to campaign generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 1. Create a campaign:
 
   ```bash
-  rails generate heya:campaign Onboarding welcome
+  rails generate heya:campaign Onboarding welcome:0
   ```
 
 2. Add a user to your campaign:

--- a/lib/generators/heya/campaign/USAGE
+++ b/lib/generators/heya/campaign/USAGE
@@ -2,7 +2,7 @@ Description:
     Generate a new campaign
 
 Example:
-    rails generate heya:campaign Onboarding first second third
+    rails generate heya:campaign Onboarding first:0 second:2.days third
 
     This will create:
         app/campaigns/onboarding_campaign.rb

--- a/lib/generators/heya/campaign/campaign_generator.rb
+++ b/lib/generators/heya/campaign/campaign_generator.rb
@@ -35,6 +35,7 @@ class Heya::CampaignGenerator < Rails::Generators::NamedBase
       end
 
     steps.each do |step|
+      step, _wait = step.split(":")
       @step = step
       template_method.call(step)
     end

--- a/lib/generators/heya/campaign/templates/campaign.rb.tt
+++ b/lib/generators/heya/campaign/templates/campaign.rb.tt
@@ -1,7 +1,4 @@
-class <%= file_name.camelcase %>Campaign < ApplicationCampaign
-<% steps.each do |step| %>
-  step :<%= step.underscore.to_sym %>,
+class <%= file_name.camelcase %>Campaign < ApplicationCampaign<% steps.each do |step| %><% step, wait = step.split(":") %>
+  step :<%= step.underscore.to_sym %>,<%= wait.presence ? "\n    wait: #{wait}," : "" %>
     subject: "<%= step.humanize %> Message"
-
-<% end -%>
-end
+<% end %>end

--- a/lib/generators/heya/campaign/templates/campaign.rb.tt
+++ b/lib/generators/heya/campaign/templates/campaign.rb.tt
@@ -1,4 +1,4 @@
 class <%= file_name.camelcase %>Campaign < ApplicationCampaign<% steps.each do |step| %><% step, wait = step.split(":") %>
   step :<%= step.underscore.to_sym %>,<%= wait.presence ? "\n    wait: #{wait}," : "" %>
-    subject: "<%= step.humanize %> Message"
+    subject: "<%= step.humanize %>"
 <% end %>end


### PR DESCRIPTION
This allows me to set the wait time for each message in the generator
arguments, i.e.:

```ruby
rails g heya:campaign Onboarding first:0 second:2.days third
```

This assumes that anything after the optional : separator is a valid
Ruby duration (which gets inserted as an option in the campaign file).

This is especially useful when you want to send the first message
immediately, as all messages default to a wait time of 2 days.

This also cleans up some whitespace in the generated campaign.