### PR TITLE
Support I18n translations for email subjects

### DIFF
--- a/app/mailers/heya/campaign_mailer.rb
+++ b/app/mailers/heya/campaign_mailer.rb
@@ -5,10 +5,17 @@ module Heya
     def build
       user = params.fetch(:user)
       step = params.fetch(:step)
-      campaign = step.campaign
+
+      campaign_name = step.campaign_name.underscore
+      step_name = step.name.underscore
+
       from = step.params.fetch("from")
       reply_to = step.params.fetch("reply_to", nil)
-      subject = step.params.fetch("subject")
+
+      subject = step.params.fetch("subject") {
+        I18n.t("#{campaign_name}.#{step_name}.subject", **attributes_for(user))
+      }
+      subject = subject.call(user) if subject.respond_to?(:call)
 
       instance_variable_set(:"@#{user.model_name.element}", user)
 
@@ -17,12 +24,20 @@ module Heya
         reply_to: reply_to,
         to: user.email,
         subject: subject,
-        template_path: "heya/campaign_mailer/#{campaign.name.underscore}",
-        template_name: step.name.underscore
+        template_path: "heya/campaign_mailer/#{campaign_name}",
+        template_name: step_name
       )
     end
 
     protected
+
+    def attributes_for(user)
+      if user.respond_to?(:heya_attributes)
+        user.heya_attributes.symbolize_keys
+      else
+        {}
+      end
+    end
 
     def _prefixes
       @_prefixes_with_campaign_path ||= begin

--- a/lib/heya/campaigns/actions/email.rb
+++ b/lib/heya/campaigns/actions/email.rb
@@ -4,6 +4,12 @@ module Heya
   module Campaigns
     module Actions
       class Email < Action
+        def self.validate_step(step)
+          unless step.params["subject"].present? || I18n.exists?("#{step.campaign_name.underscore}.#{step.name.underscore}.subject")
+            raise ArgumentError.new(%("subject" is required))
+          end
+        end
+
         def build
           CampaignMailer
             .with(user: user, step: step)

--- a/lib/heya/campaigns/actions/email.rb
+++ b/lib/heya/campaigns/actions/email.rb
@@ -4,7 +4,10 @@ module Heya
   module Campaigns
     module Actions
       class Email < Action
+        VALID_PARAMS = %w[subject from reply_to]
+
         def self.validate_step(step)
+          step.params.assert_valid_keys(VALID_PARAMS)
           unless step.params["subject"].present? || I18n.exists?("#{step.campaign_name.underscore}.#{step.name.underscore}.subject")
             raise ArgumentError.new(%("subject" is required))
           end

--- a/lib/heya/campaigns/base.rb
+++ b/lib/heya/campaigns/base.rb
@@ -140,13 +140,13 @@ module Heya
               .merge(opts)
 
           attrs = opts.select { |k, _| STEP_ATTRS.key?(k) }
-          attrs[:params] = opts.reject { |k, _| STEP_ATTRS.key?(k) }.stringify_keys
           attrs[:id] = "#{self.name}/#{name}"
           attrs[:name] = name.to_s
-          attrs[:position] = steps.size
           attrs[:campaign] = instance
+          attrs[:position] = steps.size
+          attrs[:params] = opts.reject { |k, _| STEP_ATTRS.key?(k) }.stringify_keys
 
-          step = Step.new(attrs)
+          step = Step.new(**attrs)
           method_name = :"#{step.name.underscore}"
           raise "Invalid step name: #{step.name}\n  Step names must not conflict with method names on Heya::Campaigns::Base" if respond_to?(method_name)
 

--- a/lib/heya/campaigns/step.rb
+++ b/lib/heya/campaigns/step.rb
@@ -12,12 +12,23 @@ module Heya
         campaign_name.constantize.steps.find { |s| s.id == id }
       end
 
+      def initialize(id:, name:, campaign:, position:, action:, wait:, segment:, queue:, params: {})
+        super
+        if action.respond_to?(:validate_step)
+          action.validate_step(self)
+        end
+      end
+
       def gid
         to_gid(app: "heya").to_s
       end
 
       def in_segment?(user)
         Heya.in_segments?(user, *campaign.__segments, segment)
+      end
+
+      def campaign_name
+        @campaign_name ||= campaign.name
       end
     end
   end

--- a/test/dummy/app/models/contact.rb
+++ b/test/dummy/app/models/contact.rb
@@ -1,3 +1,7 @@
 class Contact < ApplicationRecord
   store :traits, coder: JSON
+
+  def heya_attributes
+    traits
+  end
 end

--- a/test/dummy/app/views/heya/campaign_mailer/test_campaign/test.html.erb
+++ b/test/dummy/app/views/heya/campaign_mailer/test_campaign/test.html.erb
@@ -1,0 +1,1 @@
+test html content

--- a/test/dummy/app/views/heya/campaign_mailer/test_campaign/test.text.erb
+++ b/test/dummy/app/views/heya/campaign_mailer/test_campaign/test.text.erb
@@ -1,0 +1,1 @@
+test text context

--- a/test/dummy/config/locales/first_campaign_interpolation.yml
+++ b/test/dummy/config/locales/first_campaign_interpolation.yml
@@ -1,4 +1,0 @@
-first_campaign_interpolation:
-  first_campaign:
-    one:
-      subject: "Heya %{first_name}"

--- a/test/dummy/config/locales/first_campaign_interpolation.yml
+++ b/test/dummy/config/locales/first_campaign_interpolation.yml
@@ -1,0 +1,4 @@
+first_campaign_interpolation:
+  first_campaign:
+    one:
+      subject: "Heya %{first_name}"

--- a/test/dummy/config/locales/test_campaign_interpolation.yml
+++ b/test/dummy/config/locales/test_campaign_interpolation.yml
@@ -1,0 +1,4 @@
+test_campaign_interpolation:
+  test_campaign:
+    test:
+      subject: "Heya %{first_name}"

--- a/test/lib/heya/campaigns/actions/email_test.rb
+++ b/test/lib/heya/campaigns/actions/email_test.rb
@@ -10,7 +10,7 @@ module Heya
 
         test "it sends an email to user" do
           contact = contacts(:one)
-          step = FirstCampaign.steps.first
+          step = create_test_step(action: Email, subject: "expected subject")
           email = Email.new(user: contact, step: step).build
 
           assert_emails 1 do
@@ -19,6 +19,25 @@ module Heya
 
           assert_equal ["user@example.com"], email.from
           assert_equal [contact.email], email.to
+          assert_equal "expected subject", email.subject
+        end
+
+        test "it raises an exception without a subject" do
+          assert_raise ArgumentError, /subject/ do
+            create_test_step(action: Email)
+          end
+        end
+
+        test "it raises an exception with invalid params" do
+          assert_raise ArgumentError, /invalid/ do
+            create_test_step(action: Email, subject: "heya", invalid: true)
+          end
+        end
+
+        test "it doesn't raise exception with locale" do
+          I18n.with_locale(:test_campaign_interpolation) do
+            assert_kind_of Step, create_test_step(action: Email)
+          end
         end
       end
     end

--- a/test/lib/heya/campaigns/step_test.rb
+++ b/test/lib/heya/campaigns/step_test.rb
@@ -6,12 +6,9 @@ module Heya
   module Campaigns
     class StepTest < ActiveSupport::TestCase
       test "it checks segment for user" do
-        campaign = Class.new(Base) {
+        campaign = create_test_campaign {
           step :one, segment: ->(c) { c.traits["name"] != "Jack" }
           user_type "Contact"
-          def self.name
-            "TestCampaign"
-          end
         }
         step = campaign.steps.first
         contact = contacts(:one)

--- a/test/mailers/heya/campaign_mailer_test.rb
+++ b/test/mailers/heya/campaign_mailer_test.rb
@@ -14,6 +14,33 @@ module Heya
       end
 
       assert_equal ["user@example.com"], email.from
+      assert_equal "First subject", email.subject
+    end
+
+    test "it falls back to i18n for subject" do
+      contact = contacts(:one)
+      step = FirstCampaign.steps.first.dup
+
+      step.params = step.params.dup
+      step.params.delete("subject")
+      contact.traits["first_name"] = "Hunter"
+
+      I18n.with_locale(:first_campaign_interpolation) do
+        email = CampaignMailer.with(user: contact, step: step).build
+        assert_equal "Heya Hunter", email.subject
+      end
+    end
+
+    test "it calls block for subject" do
+      contact = contacts(:one)
+      step = FirstCampaign.steps.first.dup
+
+      step.params = step.params.dup
+      step.params["subject"] = ->(u) { "Heya #{u.traits["first_name"]}" }
+      contact.traits["first_name"] = "Hunter"
+      email = CampaignMailer.with(user: contact, step: step).build
+
+      assert_equal "Heya Hunter", email.subject
     end
   end
 end

--- a/test/mailers/heya/campaign_mailer_test.rb
+++ b/test/mailers/heya/campaign_mailer_test.rb
@@ -6,7 +6,10 @@ module Heya
   class CampaignMailerTest < ActionMailer::TestCase
     test "it delivers campaign emails with defaults" do
       contact = contacts(:one)
-      step = FirstCampaign.steps.first
+      step = create_test_step(
+        action: Campaigns::Actions::Email,
+        subject: "Expected subject"
+      )
       email = CampaignMailer.with(user: contact, step: step).build
 
       assert_emails 1 do
@@ -14,18 +17,15 @@ module Heya
       end
 
       assert_equal ["user@example.com"], email.from
-      assert_equal "First subject", email.subject
+      assert_equal "Expected subject", email.subject
     end
 
     test "it falls back to i18n for subject" do
       contact = contacts(:one)
-      step = FirstCampaign.steps.first.dup
-
-      step.params = step.params.dup
-      step.params.delete("subject")
       contact.traits["first_name"] = "Hunter"
 
-      I18n.with_locale(:first_campaign_interpolation) do
+      I18n.with_locale(:test_campaign_interpolation) do
+        step = create_test_step(action: Campaigns::Actions::Email)
         email = CampaignMailer.with(user: contact, step: step).build
         assert_equal "Heya Hunter", email.subject
       end
@@ -33,11 +33,11 @@ module Heya
 
     test "it calls block for subject" do
       contact = contacts(:one)
-      step = FirstCampaign.steps.first.dup
-
-      step.params = step.params.dup
-      step.params["subject"] = ->(u) { "Heya #{u.traits["first_name"]}" }
       contact.traits["first_name"] = "Hunter"
+      step = create_test_step(
+        action: Campaigns::Actions::Email,
+        subject: ->(u) { "Heya #{u.traits["first_name"]}" }
+      )
       email = CampaignMailer.with(user: contact, step: step).build
 
       assert_equal "Heya Hunter", email.subject

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,6 +37,15 @@ class NullMail
   end
 end
 
+class NullAction
+  def initialize(step:, user:)
+  end
+
+  def deliver_later
+    true
+  end
+end
+
 module Heya::Campaigns
   class TestAction < Action
     class Message
@@ -65,13 +74,14 @@ module Heya::Campaigns
 end
 
 class ActiveSupport::TestCase
-  def create_test_campaign(name: "TestCampaign", parent: Heya::Campaigns::Base, &block)
+  def create_test_campaign(name: "TestCampaign", parent: Heya::Campaigns::Base, action: NullAction, &block)
     klass = Class.new(parent) {
       class << self
         attr_accessor :name
       end
     }
     klass.name = name
+    klass.default(action: action)
     klass.instance_exec(&block)
     klass
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -86,6 +86,12 @@ class ActiveSupport::TestCase
     klass
   end
 
+  def create_test_step(**params)
+    create_test_campaign do
+      step :test, **params
+    end.steps.first
+  end
+
   def generate_license(starts_at: Date.today, expires_at: 1.year.from_now.to_date, name: "Name", company: "Company", email: "user@example.com", user_count: nil)
     original_key = Heya::License.encryption_key
 


### PR DESCRIPTION
Closes #62 

Given a campaign `OnboardingCampaign` and a step named `welcome`, the
email subject will be created from the following locale if available:

```
en:
  onboarding_campaign:
    welcome:
      subject: "Heya %{first_name}"
```

This adds a few new concepts which may continue to develop over time:

1. Define `#heya_attributes` on your `User` model to make attributes
   available to Heya in translations through interpolation. I think this
   has other applications, but I haven't fully thought out what
   they may be.

2. Step validation. Actions may now define a `validate_step` method
   which raises `ArgumentError` when a required key is missing.

   For example, you never want to send an email without a subject.
   Validating the required keys when the step is defined means that the
   application will crash preemptively.

   This is similar to `validate_options` in ActiveRecord:
   https://github.com/rails/rails/blob/v6.0.3/activerecord/lib/active_record/associations/builder/association.rb#L66

   The alternative is to wait for the action to be built inside of a
   background job (when actually trying to send an email) before
   crashing, but then the job would be retried up to the limit, and the
   email could potentially be lost.

3. Subject lambdas: in addition to passing in your subject as a
   `String`, you can optionally pass a proc/lambda:

   ```
   step :welcome,
     subject: ->(user) { "Heya #{user.first_name}" }
   ```