### PR TITLE
Track the next step in the scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added the `step_gid` column to the `heya_campaign_memberships` table. This
+  change requires running a migration to upgrade.
 
 ## [0.3.0] - 2020-06-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Added the `step_gid` column to the `heya_campaign_memberships` table. This
-  change requires running a migration to upgrade.
+  change requires running a migration to upgrade. [Instructions](./UPGRADING.md#004). (#83)
 
 ## [0.3.0] - 2020-06-02
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heya (0.2.1)
+    heya (0.3.0)
       rails (>= 5.2.3, < 6.1.0)
 
 GEM
@@ -91,7 +91,7 @@ GEM
     minitest (5.14.2)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
-    nio4r (2.5.3)
+    nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.2)
@@ -158,7 +158,7 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/README.md
+++ b/README.md
@@ -543,6 +543,13 @@ Yep. Use the `restart` option to resend a campaign to a user (if they are alread
 Yep. By default, Heya sends campaigns ain order of `priority`. Use the `concurrent` option to send campaigns concurrently.
 </details>
 
+## Upgrading Heya
+Heya adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), and
+should be considered **unstable** until version 1.0.0. Always check
+[CHANGELOG.md](./CHANGELOG.md) prior to upgrading (breaking changes will always
+be called out there). Upgrade instructions for breaking changes are in
+[UPGRADING.md](./UPGRADING.md).
+
 ## Roadmap
 See [here](https://github.com/honeybadger-io/heya/projects/1) for things we're
 considering adding to Heya.
@@ -550,7 +557,7 @@ considering adding to Heya.
 ## Contributing
 1. Fork it.
 2. Create a topic branch `git checkout -b my_branch`
-3. Make your changes and add an entry to the [CHANGELOG](CHANGELOG.md).
+3. Make your changes and add an entry to [CHANGELOG.md](CHANGELOG.md).
 4. Commit your changes `git commit -am "Boom"`
 5. Push to your branch `git push origin my_branch`
 6. Send a [pull request](https://github.com/honeybadger-io/heya/pulls)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,20 @@
+# Upgrading Heya
+
+## 0.0.4
+If you're upgrading from Heya `<= 0.0.3`, you will need the following migration:
+
+```
+class AddStepGidToHeyaCampaignMemberships < ActiveRecord::Migration[6.0]
+  def up
+    add_column :heya_campaign_memberships, :step_gid, :string
+    Heya::CampaignMembership.migrate_next_step!
+    change_column :heya_campaign_memberships, :step_gid, :string, null: false
+  end
+
+  def down
+    remove_column :heya_campaign_memberships, :step_gid, :string
+  end
+end
+```
+
+See [CHANGELOG.md](./CHANGELOG.md) for more info.

--- a/app/models/heya/campaign_membership.rb
+++ b/app/models/heya/campaign_membership.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Heya
   class CampaignMembership < ApplicationRecord
     belongs_to :user, polymorphic: true
@@ -5,6 +7,62 @@ module Heya
     before_create do
       self.last_sent_at = Time.now
     end
+
+    scope :with_steps, -> {
+      joins(
+        %(INNER JOIN "heya_steps" ON "heya_steps".gid = "heya_campaign_memberships".step_gid)
+      )
+    }
+
+    scope :active, -> {
+      priority_gids = Heya.config.campaigns.priority.map { |c| (c.is_a?(String) ? c.constantize : c).gid }
+      where(<<~SQL, priority_gids: priority_gids)
+        "heya_campaign_memberships".concurrent = TRUE
+        OR "heya_campaign_memberships"."campaign_gid" IN (
+          SELECT
+            "active_membership"."campaign_gid"
+          FROM
+            "heya_campaign_memberships" as "active_membership"
+          WHERE
+            "active_membership"."concurrent" = FALSE
+            AND
+            (
+              "active_membership".user_type = "heya_campaign_memberships".user_type
+              AND
+              "active_membership".user_id = "heya_campaign_memberships".user_id
+            )
+          ORDER BY
+            array_position(ARRAY[:priority_gids], "active_membership".campaign_gid::text) ASC,
+            "active_membership".created_at ASC
+          LIMIT 1
+        )
+      SQL
+    }
+
+    scope :upcoming, -> {
+      with_steps
+        .active
+        .order(
+          Arel.sql(
+            %("heya_campaign_memberships".last_sent_at + make_interval(secs := "heya_steps".wait) DESC)
+          )
+        )
+    }
+
+    scope :to_process, ->(now: Time.now, user: nil) {
+      upcoming
+        .where(<<~SQL, now: now.utc, user_type: user&.class&.base_class&.name, user_id: user&.id)
+          ("heya_campaign_memberships".last_sent_at <= (TIMESTAMP :now - make_interval(secs := "heya_steps".wait)))
+          AND (
+            (:user_type IS NULL OR :user_id IS NULL)
+            OR (
+              "heya_campaign_memberships".user_type = :user_type
+              AND
+              "heya_campaign_memberships".user_id = :user_id
+            )
+          )
+        SQL
+    }
 
     def self.migrate_next_step!
       find_each do |membership|

--- a/app/models/heya/campaign_membership.rb
+++ b/app/models/heya/campaign_membership.rb
@@ -5,5 +5,28 @@ module Heya
     before_create do
       self.last_sent_at = Time.now
     end
+
+    def self.migrate_next_step!
+      find_each do |membership|
+        campaign = GlobalID::Locator.locate(membership.campaign_gid)
+        receipt = campaign && CampaignReceipt.where(user: membership.user, step_gid: campaign.steps.map(&:gid)).order('created_at desc').first
+
+        next_step = if receipt
+                      last_step = GlobalID::Locator.locate(receipt.step_gid)
+                      current_index = campaign.steps.index(last_step)
+                      campaign.steps[current_index + 1]
+                    else
+                      campaign&.steps&.first
+                    end
+
+        if next_step
+          membership.update(step_gid: next_step.gid)
+        else
+          membership.destroy
+        end
+      end
+
+      CampaignReceipt.where(sent_at: nil).destroy_all
+    end
   end
 end

--- a/app/models/heya/campaign_membership.rb
+++ b/app/models/heya/campaign_membership.rb
@@ -9,15 +9,15 @@ module Heya
     def self.migrate_next_step!
       find_each do |membership|
         campaign = GlobalID::Locator.locate(membership.campaign_gid)
-        receipt = campaign && CampaignReceipt.where(user: membership.user, step_gid: campaign.steps.map(&:gid)).order('created_at desc').first
+        receipt = campaign && CampaignReceipt.where(user: membership.user, step_gid: campaign.steps.map(&:gid)).order("created_at desc").first
 
         next_step = if receipt
-                      last_step = GlobalID::Locator.locate(receipt.step_gid)
-                      current_index = campaign.steps.index(last_step)
-                      campaign.steps[current_index + 1]
-                    else
-                      campaign&.steps&.first
-                    end
+          last_step = GlobalID::Locator.locate(receipt.step_gid)
+          current_index = campaign.steps.index(last_step)
+          campaign.steps[current_index + 1]
+        else
+          campaign&.steps&.first
+        end
 
         if next_step
           membership.update(step_gid: next_step.gid)

--- a/lib/generators/heya/install/templates/migration.rb.tt
+++ b/lib/generators/heya/install/templates/migration.rb.tt
@@ -4,6 +4,7 @@ class CreateHeyaTables < ActiveRecord::Migration[<%= ActiveRecord::VERSION::MAJO
       t.references :user, null: false, polymorphic: true, index: false
 
       t.string :campaign_gid, null: false
+      t.string :step_gid, null: false
       t.boolean :concurrent, null: false, default: false
 
       t.datetime :last_sent_at, null: false

--- a/lib/heya.rb
+++ b/lib/heya.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "heya/version"
+require "heya/active_record_extension"
 require "heya/engine"
 require "heya/config"
 require "heya/license"

--- a/lib/heya/active_record_extension.rb
+++ b/lib/heya/active_record_extension.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "active_record/relation"
+
+module Heya
+  module ActiveRecordRelationExtension
+    TABLE_REGEXP = /heya_steps/
+
+    def build_arel(aliases)
+      arel = super(aliases)
+
+      if table_name == "heya_campaign_memberships" && arel.to_sql =~ TABLE_REGEXP
+        # https://www.postgresql.org/docs/9.4/queries-values.html
+        values = Heya
+          .campaigns.reduce([]) { |steps, campaign| steps | campaign.steps }
+          .map { |step|
+            ActiveRecord::Base.sanitize_sql_array(
+              ["(?, ?)", step.gid, step.wait.to_i]
+            )
+          }
+
+        if values.any?
+          arel.with(
+            Arel::Nodes::SqlLiteral.new(
+              "heya_steps AS (SELECT * FROM (VALUES #{values.join(", ")}) AS heya_steps (gid,wait))"
+            )
+          )
+        end
+      end
+
+      arel
+    end
+  end
+
+  ActiveRecord::Relation.prepend(ActiveRecordRelationExtension)
+end

--- a/lib/heya/campaigns/queries.rb
+++ b/lib/heya/campaigns/queries.rb
@@ -23,9 +23,9 @@ module Heya
         end
       }
 
-      # Given a campaign, {Queries::OrphanedStepMemberships} returns the campaign
+      # Given a campaign, {Queries::OrphanedMemberships} returns the campaign
       # memberships which are on steps have been removed from the campaign.
-      OrphanedStepMemberships = ->(campaign) {
+      OrphanedMemberships = ->(campaign) {
         CampaignMembership
           .where(campaign_gid: campaign.gid)
           .where.not(step_gid: campaign.steps.map(&:gid))

--- a/lib/heya/campaigns/queries.rb
+++ b/lib/heya/campaigns/queries.rb
@@ -3,88 +3,10 @@
 module Heya
   module Campaigns
     module Queries
-      MEMBERSHIP_QUERY = <<~SQL
-        WITH
-          steps AS (SELECT * FROM (VALUES :steps_values) AS steps (gid,wait))
-        SELECT
-          "memberships".*
-        FROM
-          "heya_campaign_memberships" AS "memberships"
-          INNER JOIN
-            "steps" ON "steps".gid = "memberships".step_gid
-        WHERE ("memberships".last_sent_at <= (TIMESTAMP :now - make_interval(secs := "steps".wait)))
-        AND (
-          (:user_type IS NULL OR :user_id IS NULL)
-          OR (
-            "memberships".user_type = :user_type
-            AND
-            "memberships".user_id = :user_id
-          )
-        )
-        AND (
-          ("memberships".concurrent = TRUE)
-          OR "memberships"."campaign_gid" IN (
-            SELECT
-              "active_membership"."campaign_gid"
-            FROM
-              "heya_campaign_memberships" as "active_membership"
-            WHERE
-              "active_membership"."concurrent" = FALSE
-              AND
-              (
-                "active_membership".user_type = "memberships".user_type
-                AND
-                "active_membership".user_id = "memberships".user_id
-              )
-            ORDER BY
-              array_position(ARRAY[:priority_gids], "active_membership".campaign_gid::text) ASC,
-              "active_membership".created_at ASC
-            LIMIT 1
-          )
-        )
-        ORDER BY
-          "memberships"."created_at" ASC
-        LIMIT :limit
-        OFFSET :offset
-      SQL
-
       # {Queries::MembershipsToProcess} returns the CampaignMembership records
       # which should be processed by the scheduler.
-      MembershipsToProcess = ->(user: nil, &block) {
-        now = Time.now.utc
-
-        # https://www.postgresql.org/docs/9.4/queries-values.html
-        steps_values = Heya
-          .campaigns.reduce([]) { |steps, campaign| steps | campaign.steps }
-          .map { |step|
-            ActiveRecord::Base.sanitize_sql_array(
-              ["(?, ?)", step.gid, step.wait.to_i]
-            )
-          }.join(", ")
-
-        priority_gids = Heya.config.campaigns.priority.map { |c| (c.is_a?(String) ? c.constantize : c).gid }
-
-        offset = 0
-        limit = 1000
-
-        prepared_query = MEMBERSHIP_QUERY.gsub(":steps_values", steps_values)
-        loop do
-          memberships = CampaignMembership.find_by_sql(
-            ActiveRecord::Base.sanitize_sql_array(
-              [prepared_query, {
-                now: now,
-                priority_gids: priority_gids,
-                limit: limit,
-                offset: offset,
-                user_type: user&.class&.base_class&.name,
-                user_id: user&.id
-              }]
-            )
-          )
-          memberships.each { |membership| block.call(membership) }
-          break if memberships.size < limit
-          offset += limit
-        end
+      MembershipsToProcess = ->(user: nil) {
+        Heya::CampaignMembership.to_process(user: user)
       }
 
       # Given a campaign and a user, {Queries::MembershipsForUpdate}

--- a/lib/heya/campaigns/queries.rb
+++ b/lib/heya/campaigns/queries.rb
@@ -3,97 +3,94 @@
 module Heya
   module Campaigns
     module Queries
-      NEXT_STEP_SUBQUERY = <<~SQL
-        (WITH steps AS (SELECT * FROM (VALUES :steps_values) AS m (step_gid,campaign_gid,position))
-         SELECT m.step_gid FROM steps AS m
-         WHERE m.campaign_gid = :campaign_gid
-           AND m.position > coalesce((SELECT m.position FROM heya_campaign_receipts AS r
-             INNER JOIN steps AS m ON m.step_gid = r.step_gid
-               AND m.campaign_gid = :campaign_gid
-             WHERE r.user_type = heya_campaign_memberships.user_type
-               AND r.user_id = heya_campaign_memberships.user_id
-             ORDER BY m.position DESC
-             LIMIT 1), -1)
-         ORDER BY m.position ASC
-         LIMIT 1
-        ) = :step_gid
+      MEMBERSHIP_QUERY = <<~SQL
+        WITH
+          steps AS (SELECT * FROM (VALUES :steps_values) AS steps (gid,wait))
+        SELECT
+          "memberships".*
+        FROM
+          "heya_campaign_memberships" AS "memberships"
+          INNER JOIN
+            "steps" ON "steps".gid = "memberships".step_gid
+        WHERE ("memberships".last_sent_at <= (TIMESTAMP :now - make_interval(secs := "steps".wait)))
+        AND (
+          (:user_type IS NULL OR :user_id IS NULL)
+          OR (
+            "memberships".user_type = :user_type
+            AND
+            "memberships".user_id = :user_id
+          )
+        )
+        AND (
+          ("memberships".concurrent = TRUE)
+          OR "memberships"."campaign_gid" IN (
+            SELECT
+              "active_membership"."campaign_gid"
+            FROM
+              "heya_campaign_memberships" as "active_membership"
+            WHERE
+              "active_membership"."concurrent" = FALSE
+              AND
+              (
+                "active_membership".user_type = "memberships".user_type
+                AND
+                "active_membership".user_id = "memberships".user_id
+              )
+            ORDER BY
+              array_position(ARRAY[:priority_gids], "active_membership".campaign_gid::text) ASC,
+              "active_membership".created_at ASC
+            LIMIT 1
+          )
+        )
+        ORDER BY
+          "memberships"."created_at" ASC
+        LIMIT :limit
+        OFFSET :offset
       SQL
 
-      ACTIVE_CAMPAIGN_SUBQUERY = <<~SQL
-        (WITH heya_campaigns AS (SELECT * FROM (VALUES :campaigns_values) AS campaigns (campaign_gid,position))
-        SELECT memberships.campaign_gid FROM heya_campaign_memberships AS memberships
-         INNER JOIN heya_campaigns AS campaigns
-           ON campaigns.campaign_gid = memberships.campaign_gid
-         WHERE memberships.user_type = heya_campaign_memberships.user_type
-           AND memberships.user_id = heya_campaign_memberships.user_id
-           AND memberships.concurrent = FALSE
-         ORDER BY campaigns.position DESC, memberships.created_at ASC
-         LIMIT 1
-        ) = :campaign_gid
-      SQL
-
-      # Given a campaign and a step, {Queries::UsersForStep} returns the
-      # users who should complete the step.
-      UsersForStep = ->(campaign, step) {
-        wait_threshold = Time.now.utc - step.wait
-
-        # Safeguard to make sure we never complete the same step twice.
-        receipt_query = CampaignReceipt
-          .select("heya_campaign_receipts.user_id")
-          .where(user_type: campaign.user_class.name)
-          .where("heya_campaign_receipts.step_gid = ?", step.gid)
+      # {Queries::MembershipsToProcess} returns the CampaignMembership records
+      # which should be processed by the scheduler.
+      MembershipsToProcess = ->(user: nil, &block) {
+        now = Time.now.utc
 
         # https://www.postgresql.org/docs/9.4/queries-values.html
-        steps_values = campaign.steps.map { |m|
-          ActiveRecord::Base.sanitize_sql_array(
-            ["(?, ?, ?)", m.gid, campaign.gid, m.position]
-          )
-        }.join(", ")
+        steps_values = Heya
+          .campaigns.reduce([]) { |steps, campaign| steps | campaign.steps }
+          .map { |step|
+            ActiveRecord::Base.sanitize_sql_array(
+              ["(?, ?)", step.gid, step.wait.to_i]
+            )
+          }.join(", ")
 
-        priority = Heya.config.campaigns.priority.reverse.map { |c| c.is_a?(String) ? c : c.name }
-        campaigns_values = Heya.campaigns.map { |c|
-          ActiveRecord::Base.sanitize_sql_array(
-            ["(?, ?)", c.gid, priority.index(c.name) || -1]
-          )
-        }.join(", ")
+        priority_gids = Heya.config.campaigns.priority.map { |c| (c.is_a?(String) ? c.constantize : c).gid }
 
-        users = campaign.users
-        users
-          .where.not(id: receipt_query)
-          .where(NEXT_STEP_SUBQUERY.gsub(":steps_values", steps_values), {
-            campaign_gid: campaign.gid,
-            step_gid: step.gid
-          })
-          .merge(
-            users
-              .where("heya_campaign_memberships.concurrent = ?", true)
-              .or(
-                users.where(ACTIVE_CAMPAIGN_SUBQUERY.gsub(":campaigns_values", campaigns_values), {
-                  campaign_gid: campaign.gid
-                })
-              )
+        offset = 0
+        limit = 1000
+
+        prepared_query = MEMBERSHIP_QUERY.gsub(":steps_values", steps_values)
+        loop do
+          memberships = CampaignMembership.find_by_sql(
+            ActiveRecord::Base.sanitize_sql_array(
+              [prepared_query, {
+                now: now,
+                priority_gids: priority_gids,
+                limit: limit,
+                offset: offset,
+                user_type: user&.class&.base_class&.name,
+                user_id: user&.id
+              }]
+            )
           )
-          .where(
-            "heya_campaign_memberships.last_sent_at <= ?", wait_threshold
-          )
+          memberships.each { |membership| block.call(membership) }
+          break if memberships.size < limit
+          offset += limit
+        end
       }
 
-      # Given a campaign and a step, {Queries::UsersCompletedStep}
-      # returns the users who have completed the step.
-      UsersCompletedStep = ->(campaign, step) {
-        receipt_query = CampaignReceipt
-          .select("heya_campaign_receipts.user_id")
-          .where(user_type: campaign.user_class.name)
-          .where("heya_campaign_receipts.step_gid = ?", step.gid)
-
-        campaign.users
-          .where(id: receipt_query)
-      }
-
-      # Given a campaign and a user, {Queries::CampaignMembershipsForUpdate}
+      # Given a campaign and a user, {Queries::MembershipsForUpdate}
       # returns the user's campaign memberships which should be updated
       # concurrently.
-      CampaignMembershipsForUpdate = ->(campaign, user) {
+      MembershipsForUpdate = ->(campaign, user) {
         membership = CampaignMembership.where(user: user, campaign_gid: campaign.gid).first
         if membership.concurrent?
           CampaignMembership
@@ -104,14 +101,12 @@ module Heya
         end
       }
 
-      # Given a campaign, {Queries::OrphanedCampaignMemberships} returns the
-      # campaign memberships which belong to users who no longer exist in the
-      # database.
-      OrphanedCampaignMemberships = ->(campaign) {
+      # Given a campaign, {Queries::OrphanedStepMemberships} returns the campaign
+      # memberships which are on steps have been removed from the campaign.
+      OrphanedStepMemberships = ->(campaign) {
         CampaignMembership
           .where(campaign_gid: campaign.gid)
-          .where(user_type: campaign.user_class.base_class.name)
-          .where.not(user_id: campaign.users.select("id"))
+          .where.not(step_gid: campaign.steps.map(&:gid))
       }
     end
   end

--- a/lib/heya/campaigns/scheduler.rb
+++ b/lib/heya/campaigns/scheduler.rb
@@ -18,7 +18,7 @@ module Heya
           end
         end
 
-        Queries::MembershipsToProcess.call(user: user) do |membership|
+        Queries::MembershipsToProcess.call(user: user).find_each do |membership|
           step = GlobalID::Locator.locate(membership.step_gid)
           campaign = GlobalID::Locator.locate(membership.campaign_gid)
           process(campaign, step, membership.user)

--- a/lib/heya/campaigns/scheduler.rb
+++ b/lib/heya/campaigns/scheduler.rb
@@ -14,7 +14,7 @@ module Heya
       def run(user: nil)
         Heya.campaigns.each do |campaign|
           if campaign.steps.any?
-            Queries::OrphanedStepMemberships.call(campaign).update_all(step_gid: campaign.steps.first.gid)
+            Queries::OrphanedMemberships.call(campaign).update_all(step_gid: campaign.steps.first.gid)
           end
         end
 

--- a/lib/heya/campaigns/scheduler.rb
+++ b/lib/heya/campaigns/scheduler.rb
@@ -11,36 +11,37 @@ module Heya
     #   3. Create CampaignReceipt (excludes user in subsequent steps)
     #   4. Process job
     class Scheduler
-      def run
+      def run(user: nil)
         Heya.campaigns.each do |campaign|
-          Queries::OrphanedCampaignMemberships.call(campaign).delete_all
-
-          campaign.steps.each do |step|
-            Queries::UsersForStep.call(campaign, step).find_each do |user|
-              self.class.process(campaign, step, user)
-            end
+          if campaign.steps.any?
+            Queries::OrphanedStepMemberships.call(campaign).update_all(step_gid: campaign.steps.first.gid)
           end
+        end
 
-          if (last_step = campaign.steps.last)
-            CampaignMembership.where(
-              user: Queries::UsersCompletedStep.call(campaign, last_step),
-              campaign_gid: campaign.gid
-            ).delete_all
+        Queries::MembershipsToProcess.call(user: user) do |membership|
+          step = GlobalID::Locator.locate(membership.step_gid)
+          campaign = GlobalID::Locator.locate(membership.campaign_gid)
+          process(campaign, step, membership.user)
+          current_index = campaign.steps.index(step)
+          if (next_step = campaign.steps[current_index + 1])
+            membership.update(step_gid: next_step.gid)
+          else
+            membership.destroy
           end
         end
       end
 
-      def self.process(campaign, step, user)
+      private
+
+      def process(campaign, step, user)
         ActiveRecord::Base.transaction do
           return if CampaignReceipt.where(user: user, step_gid: step.gid).exists?
 
           if step.in_segment?(user)
             now = Time.now.utc
-            Queries::CampaignMembershipsForUpdate.call(campaign, user).update_all(last_sent_at: now)
+            Queries::MembershipsForUpdate.call(campaign, user).update_all(last_sent_at: now)
             CampaignReceipt.create!(user: user, step_gid: step.gid, sent_at: now)
             step.action.new(user: user, step: step).deliver_later
-          else
-            CampaignReceipt.create!(user: user, step_gid: step.gid)
           end
         end
       end

--- a/test/dummy/app/campaigns/first_campaign.rb
+++ b/test/dummy/app/campaigns/first_campaign.rb
@@ -1,4 +1,5 @@
 class FirstCampaign < Heya::Campaigns::Base
   step :one, subject: "First subject"
   step :two, subject: "Second subject"
+  step :three, subject: "Third subject"
 end

--- a/test/dummy/app/models/contact.rb
+++ b/test/dummy/app/models/contact.rb
@@ -1,4 +1,6 @@
 class Contact < ApplicationRecord
+  has_many :heya_campaign_memberships, class_name: "Heya::CampaignMembership", as: :user, dependent: :delete_all
+  has_many :heya_campaign_receipts, class_name: "Heya::CampaignReceipt", as: :user, dependent: :delete_all
   store :traits, coder: JSON
 
   def heya_attributes

--- a/test/dummy/db/migrate/20200214174703_create_heya_tables.rb
+++ b/test/dummy/db/migrate/20200214174703_create_heya_tables.rb
@@ -4,6 +4,7 @@ class CreateHeyaTables < ActiveRecord::Migration[6.0]
       t.references :user, null: false, polymorphic: true, index: false
 
       t.string :campaign_gid, null: false
+      t.string :step_gid, null: false
       t.boolean :concurrent, null: false, default: false
 
       t.datetime :last_sent_at, null: false

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2020_02_14_174703) do
     t.string "user_type", null: false
     t.bigint "user_id", null: false
     t.string "campaign_gid", null: false
+    t.string "step_gid", null: false
     t.boolean "concurrent", default: false, null: false
     t.datetime "last_sent_at", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/test/lib/heya/campaigns/base_test.rb
+++ b/test/lib/heya/campaigns/base_test.rb
@@ -89,6 +89,7 @@ module Heya
       test "it adds and removes users from campaign" do
         campaign = create_test_campaign(name: "Test") {
           user_type "Contact"
+          step :one
         }
         membership = CampaignMembership.where(user: contacts(:one), campaign_gid: campaign.gid)
 
@@ -150,6 +151,7 @@ module Heya
       test "#add skips user when already in campaign" do
         campaign = create_test_campaign {
           user_type "Contact"
+          step :one
         }
         contact = contacts(:one)
 
@@ -179,16 +181,6 @@ module Heya
         contact.update_attribute(:traits, {foo: "bar"})
 
         assert campaign.add(contact)
-      end
-
-      test "it finds users for campaign" do
-        campaign = create_test_campaign(name: "Test") {
-          user_type "Contact"
-        }
-        CampaignMembership.create(user: contacts(:one), campaign_gid: campaign.gid)
-        CampaignMembership.create(user: contacts(:one), campaign_gid: "gid://dummy/Other/1")
-
-        assert_equal [contacts(:one)], campaign.users
       end
 
       test "it creates steps with String names" do

--- a/test/lib/heya/campaigns/scheduler_test.rb
+++ b/test/lib/heya/campaigns/scheduler_test.rb
@@ -135,7 +135,7 @@ module Heya
           user: contact,
           step: campaign.steps.third
         }])
-        run_once
+        run_twice
         assert_mock action
       end
 
@@ -230,6 +230,8 @@ module Heya
 
         assert CampaignMembership.where(campaign_gid: campaign.gid, user: contact).exists?
 
+        run_once
+        run_once
         run_once
 
         refute CampaignMembership.where(campaign_gid: campaign.gid, user: contact).exists?
@@ -435,9 +437,6 @@ module Heya
         assert membership.where(user_id: contact2.id).exists?
 
         contact1.destroy
-
-        assert membership.where(user_id: contact1.id).exists?
-        assert membership.where(user_id: contact2.id).exists?
 
         run_once
 

--- a/test/models/heya/campaign_membership_test.rb
+++ b/test/models/heya/campaign_membership_test.rb
@@ -13,5 +13,61 @@ module Heya
 
       assert membership.last_sent_at.is_a?(Time)
     end
+
+    test ".migrate_next_step! selects first step" do
+      membership = CampaignMembership.create(
+        campaign_gid: FirstCampaign.gid,
+        step_gid: "gid://heya/null",
+        user: contacts(:one)
+      )
+
+      CampaignMembership.migrate_next_step!
+
+      assert_equal FirstCampaign.steps.first.gid, membership.reload.step_gid
+    end
+
+    test ".migrate_next_step! selects next step" do
+      membership = CampaignMembership.create(
+        campaign_gid: FirstCampaign.gid,
+        step_gid: "gid://heya/null",
+        user: contacts(:one)
+      )
+      CampaignReceipt.create(user: contacts(:one), step_gid: FirstCampaign.steps.first.gid, sent_at: Time.now)
+      CampaignReceipt.create(user: contacts(:one), step_gid: FirstCampaign.steps.second.gid, sent_at: Time.now)
+
+      assert_no_difference "CampaignReceipt.count" do
+        CampaignMembership.migrate_next_step!
+      end
+
+      assert_equal FirstCampaign.steps.third.gid, membership.reload.step_gid
+    end
+
+    test ".migrate_next_step! removes orphaned memberships" do
+      CampaignMembership.create(
+        campaign_gid: 'gid://heya/null',
+        step_gid: "gid://heya/null",
+        user: contacts(:one)
+      )
+
+      assert_difference "CampaignMembership.count", -1 do
+        CampaignMembership.migrate_next_step!
+      end
+    end
+
+    test ".migrate_next_step! removes unsent receipts" do
+      membership = CampaignMembership.create(
+        campaign_gid: FirstCampaign.gid,
+        step_gid: "gid://heya/null",
+        user: contacts(:one)
+      )
+      CampaignReceipt.create(user: contacts(:one), step_gid: FirstCampaign.steps.first.gid, sent_at: nil)
+      CampaignReceipt.create(user: contacts(:one), step_gid: FirstCampaign.steps.second.gid, sent_at: Time.now)
+
+      assert_difference "CampaignReceipt.count", -1 do
+        CampaignMembership.migrate_next_step!
+      end
+
+      assert_equal FirstCampaign.steps.third.gid, membership.reload.step_gid
+    end
   end
 end

--- a/test/models/heya/campaign_membership_test.rb
+++ b/test/models/heya/campaign_membership_test.rb
@@ -7,6 +7,7 @@ module Heya
     test "it sets default last_sent_at time" do
       membership = CampaignMembership.create(
         campaign_gid: FirstCampaign.gid,
+        step_gid: FirstCampaign.steps.first.gid,
         user: contacts(:new)
       )
 

--- a/test/models/heya/contact_test.rb
+++ b/test/models/heya/contact_test.rb
@@ -4,24 +4,24 @@ require "test_helper"
 
 module Heya
   class ContactTest < ActiveSupport::TestCase
-    test "it keeps campaign memberships on destroy" do
+    test "it deletes campaign memberships on destroy" do
       contact = contacts(:one)
-      CampaignMembership.create(user: contact, campaign_gid: "foo")
+      CampaignMembership.create(user: contact, campaign_gid: "foo", step_gid: "bar")
       memberships = CampaignMembership.where(user_type: "Contact", user_id: contact.id)
 
       contact.destroy
 
-      assert memberships.any?
+      assert memberships.empty?
     end
 
-    test "it keeps campaign receipts on destroy" do
+    test "it deletes campaign receipts on destroy" do
       contact = contacts(:one)
       CampaignReceipt.create(user: contact, step_gid: "foo")
       receipts = CampaignReceipt.where(user_type: "Contact", user_id: contact.id)
 
       contact.destroy
 
-      assert receipts.any?
+      assert receipts.empty?
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -83,13 +83,15 @@ class ActiveSupport::TestCase
     klass.name = name
     klass.default(action: action)
     klass.instance_exec(&block)
+    Object.send(:remove_const, klass.name) if Object.const_defined?(klass.name.to_sym)
+    Object.send(:const_set, klass.name.to_sym, klass)
     klass
   end
 
   def create_test_step(**params)
-    create_test_campaign do
+    create_test_campaign {
       step :test, **params
-    end.steps.first
+    }.steps.first
   end
 
   def generate_license(starts_at: Date.today, expires_at: 1.year.from_now.to_date, name: "Name", company: "Company", email: "user@example.com", user_count: nil)


### PR DESCRIPTION
This PR simplifies the scheduler query by tracking the next step on the `heya_campaign_memberships` table.

The old approach used a subquery to find the user's next message based on their last message sent (joining to the `heya_campaign_receipts` table). The new approach doesn't need to perform that subquery as it already knows what step the user is on.

Because the step is stored with the membership, we no longer need to perform a separate query for each step in the scheduler; we can run a single query to get all memberships that should be sent instead. A side effect of this is that it's also no longer querying directly against the users table, so it must execute a find for each membership's user in order to check additional segments; this potentially results in more selects—basically 1 `SELECT * FROM users where id = ?` for each outgoing message. I think I could optimize this in the future by eager loading users in batches.

Another side effect (benefit) of this approach: steps that are skipped due to segments no longer require a null receipt, so users will be able to get those messages if they match on a future trip through the campaign.

The new approach should make it simpler and more efficient to query for stats and show upcoming messages in dashboards.