### PR TITLE
Fix broken Arel query in rails 6.1

### DIFF
--- a/lib/heya/active_record_extension.rb
+++ b/lib/heya/active_record_extension.rb
@@ -21,8 +21,9 @@ module Heya
 
         if values.any?
           arel.with(
-            Arel::Nodes::SqlLiteral.new(
-              "heya_steps AS (SELECT * FROM (VALUES #{values.join(", ")}) AS heya_steps (gid,wait))"
+            Arel::Nodes::As.new(
+              Arel::Table.new(:heya_steps),
+              Arel::Nodes::SqlLiteral.new("(SELECT * FROM (VALUES #{values.join(", ")}) AS heya_steps (gid,wait))")
             )
           )
         end


### PR DESCRIPTION
I was trying to get this engine running under rails 6.1 but had some problems. I saw an open PR for rails 6.1 support and noticed a few specs were failing.

I'm not super familiar with Arel, but after some experimentation I managed to get the test suite passing. Not sure if this will work on other rails versions but hopefully it will get you closer to merging support for 6.1 😄 