### PR TITLE
Fix compatibility with rails 6.1.4

### DIFF
--- a/lib/heya/active_record_extension.rb
+++ b/lib/heya/active_record_extension.rb
@@ -6,7 +6,7 @@ module Heya
   module ActiveRecordRelationExtension
     TABLE_REGEXP = /heya_steps/
 
-    def build_arel(aliases)
+    def build_arel(aliases = nil)
       arel = super(aliases)
 
       if table_name == "heya_campaign_memberships" && arel.to_sql =~ TABLE_REGEXP


### PR DESCRIPTION
When i try to run a migration ti #update_all method it generates:
```
wrong number of arguments (given 0, expected 1)
/home/deploy/docety/shared/bundle/ruby/2.7.0/bundler/gems/heya-89d0b39cec57/lib/heya/active_record_extension.rb:9:in `build_arel'
/home/deploy/docety/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.4/lib/active_record/relation.rb:443:in `update_all'
```

The ```build_arel``` method from ```active_record/relation``` has ```aliases``` params as default to nil