### PR TITLE
Allow layout override in mailers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Optional `layout` parameter for steps; allowing override from default `heya/campaign_mailer`
+
 ## [0.5.3] - 2021-08-18
 ### Added
 - Create `bcc:` optional parameter for steps; use case is quality control

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Heya uses the following additional options to build the message itself:
 | :---------- | :----------- | :------------------------- |
 | `subject`   | **required** | The email's subject        |
 | `from`      | Heya default | The sender's email address |
+| `layout`    | Heya default | The email's layout file    |
 
 You can change the default options using the `default` method at the top of the campaign. Heya applies default options to each step which doesn't supply its own:
 
@@ -257,7 +258,8 @@ You can change the default options using the `default` method at the top of the 
 class OnboardingCampaign < ApplicationCampaign
   default wait: 1.day,
     queue: "onboarding",
-    from: "support@example.com"
+    from: "support@example.com",
+    layout: "onboarding"
 
   # Will still be sent after one day from the
   # email address support@example.com

--- a/app/mailers/heya/campaign_mailer.rb
+++ b/app/mailers/heya/campaign_mailer.rb
@@ -1,6 +1,7 @@
 module Heya
   class CampaignMailer < ApplicationMailer
-    layout "heya/campaign_mailer"
+    DEFAULT_LAYOUT = "heya/campaign_mailer".freeze
+    layout -> { params.fetch(:step).params.fetch("layout", DEFAULT_LAYOUT) }
 
     def build
       user = params.fetch(:user)

--- a/lib/heya/campaigns/actions/email.rb
+++ b/lib/heya/campaigns/actions/email.rb
@@ -4,7 +4,7 @@ module Heya
   module Campaigns
     module Actions
       class Email < Action
-        VALID_PARAMS = %w[subject from reply_to bcc]
+        VALID_PARAMS = %w[subject from reply_to bcc layout]
 
         def self.validate_step(step)
           step.params.assert_valid_keys(VALID_PARAMS)


### PR DESCRIPTION
This change allows you to set a customer layout file per step, or as a default for the entire campaign.

Previously this was just defaulting to `heya/campaign_mailer`.

I'm not entirely sure how to add a unit test for this, they pass and the functionality works, but ideally I need to add one. Any suggestions welcomed.