### PR TITLE
Allow the customization of the `to` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,10 +247,11 @@ The `wait` option tells Heya how long to wait before sending each message (the d
 Heya uses the following additional options to build the message itself:
 
 | Option Name | Default      | Description                |
-| :---------- | :----------- | :------------------------- |
+|-------------|--------------|----------------------------|
 | `subject`   | **required** | The email's subject        |
 | `from`      | Heya default | The sender's email address |
 | `layout`    | Heya default | The email's layout file    |
+| `to`        | See below    | See below                  |
 
 You can change the default options using the `default` method at the top of the campaign. Heya applies default options to each step which doesn't supply its own:
 
@@ -267,6 +268,27 @@ class OnboardingCampaign < ApplicationCampaign
     subject: "Welcome to my app!"
 end
 ```
+
+#### Customizing the `to` field
+
+You can customize the `to` field by passing a callable object, which Heya will invoke with the user. For instance:
+
+```ruby
+class OnboardingCampaign < ApplicationCampaign
+  step :welcome,
+    subject: "Welcome to my app!",
+    to: -> (user) { ActionMailer::Base.email_address_with_name(user.email, user.nickname) }
+end
+```
+
+It is recommended to rely on `ActionMailer::Base.email_address_with_name` so that sanitization is correctly applied.
+
+If the `to` param is not provided, Heya will default to:
+
+1. `user#first_name`
+1. `user#name`
+
+If the `user` object doesn't respond to these methods, it will fallback to a simple `user.email` in the `to` field.
 
 #### Quality control option
 

--- a/app/mailers/heya/campaign_mailer.rb
+++ b/app/mailers/heya/campaign_mailer.rb
@@ -26,7 +26,7 @@ module Heya
         from: from,
         bcc: bcc,
         reply_to: reply_to,
-        to: user.email,
+        to: to_address(user, step),
         subject: subject,
         template_path: "heya/campaign_mailer/#{campaign_name}",
         template_name: step_name
@@ -50,6 +50,18 @@ module Heya
         else
           super
         end
+      end
+    end
+
+    def to_address(user, step)
+      return step.params["to"].call(user) if step.params["to"].respond_to?(:call)
+
+      if user.respond_to?(:first_name)
+        email_address_with_name(user.email, user.first_name)
+      elsif user.respond_to?(:name)
+        email_address_with_name(user.email, user.name)
+      else
+        user.email
       end
     end
   end

--- a/lib/heya/campaigns/actions/email.rb
+++ b/lib/heya/campaigns/actions/email.rb
@@ -4,7 +4,7 @@ module Heya
   module Campaigns
     module Actions
       class Email < Action
-        VALID_PARAMS = %w[subject from reply_to bcc layout]
+        VALID_PARAMS = %w[subject from reply_to bcc layout to]
 
         def self.validate_step(step)
           step.params.assert_valid_keys(VALID_PARAMS)


### PR DESCRIPTION
This pull request allows the user to customize the `to` field.

Currently, the gem hardcodes the `to` field to `user#email`. 

However, it is often desired to provide a readable name when sending e-mails to users, so the user's e-mail client can display that readable name instead of the pure e-mail address. 

This PR follows the gem's pattern to allow a `to` param that is a callable object, providing for great flexibility; at the same time, since the gem currently assumes `user#email`, I updated the default to use `user#first_name`, then `user#name`, which I find are reasonable defaults for the vast majority of users.