### PR TITLE
Fix license type on Heya website

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@ end</code></pre>
   <section>
     <header>
       <h2>Is Heya free to use?</h2>
-      <p>Heya is free and open source, licensed under the <a href="https://github.com/honeybadger-io/heya/blob/master/LICENSE">AGPL</a>.</p>
+      <p>Heya is free and open source, licensed under the <a href="https://github.com/honeybadger-io/heya/blob/master/LICENSE">LGPL</a>.</p>
     </header>
   </section>
 </main>


### PR DESCRIPTION
The website mistakenly says that Heya is licensed under the AGPL, when it should say `LGPL`.