### PR TITLE
Delete user-orphaned campaign memberships in scheduler

### DIFF
--- a/lib/heya/campaigns/scheduler.rb
+++ b/lib/heya/campaigns/scheduler.rb
@@ -21,7 +21,22 @@ module Heya
         Queries::MembershipsToProcess.call(user: user).find_each do |membership|
           step = GlobalID::Locator.locate(membership.step_gid)
           campaign = GlobalID::Locator.locate(membership.campaign_gid)
+
+          if membership.user.nil?
+            # User not found; delete orphaned memberships and receipts.
+            CampaignReceipt.where(
+              user_type: membership.user_type,
+              user_id: membership.user_id
+            ).delete_all
+            CampaignMembership.where(
+              user_type: membership.user_type,
+              user_id: membership.user_id
+            ).delete_all
+            next
+          end
+
           process(campaign, step, membership.user)
+
           current_index = campaign.steps.index(step)
           if (next_step = campaign.steps[current_index + 1])
             membership.update(step_gid: next_step.gid)

--- a/test/dummy/app/models/contact.rb
+++ b/test/dummy/app/models/contact.rb
@@ -1,6 +1,4 @@
 class Contact < ApplicationRecord
-  has_many :heya_campaign_memberships, class_name: "Heya::CampaignMembership", as: :user, dependent: :delete_all
-  has_many :heya_campaign_receipts, class_name: "Heya::CampaignReceipt", as: :user, dependent: :delete_all
   store :traits, coder: JSON
 
   def heya_attributes

--- a/test/lib/heya/campaigns/scheduler_test.rb
+++ b/test/lib/heya/campaigns/scheduler_test.rb
@@ -398,11 +398,10 @@ module Heya
       test "it deletes orphaned campaign memberships" do
         action = Minitest::Mock.new
         campaign = create_test_campaign {
-          default action: action
           user_type "Contact"
-          step :one, wait: 1.day
-          step :two, wait: 3.days
-          step :three, wait: 2.days
+          step :one, wait: 0
+          step :two, wait: 0
+          step :three, wait: 0
         }
         contact1 = contacts(:one)
         contact2 = contacts(:two)
@@ -413,7 +412,7 @@ module Heya
           user_type: "Contact"
         )
 
-        run_twice
+        run_once
 
         assert membership.where(user_id: contact1.id).exists?
         assert membership.where(user_id: contact2.id).exists?

--- a/test/models/heya/contact_test.rb
+++ b/test/models/heya/contact_test.rb
@@ -4,24 +4,5 @@ require "test_helper"
 
 module Heya
   class ContactTest < ActiveSupport::TestCase
-    test "it deletes campaign memberships on destroy" do
-      contact = contacts(:one)
-      CampaignMembership.create(user: contact, campaign_gid: "foo", step_gid: "bar")
-      memberships = CampaignMembership.where(user_type: "Contact", user_id: contact.id)
-
-      contact.destroy
-
-      assert memberships.empty?
-    end
-
-    test "it deletes campaign receipts on destroy" do
-      contact = contacts(:one)
-      CampaignReceipt.create(user: contact, step_gid: "foo")
-      receipts = CampaignReceipt.where(user_type: "Contact", user_id: contact.id)
-
-      contact.destroy
-
-      assert receipts.empty?
-    end
   end
 end


### PR DESCRIPTION
Fixes #177

I was able to reproduce the error described in #177 by removing the `dependent: :delete_all` associations on the contact model + fixing an existing test to send the orphaned membership through the scheduler:

<img width="1537" alt="image" src="https://user-images.githubusercontent.com/474649/177869379-5c54a880-6ffd-469b-93ac-28ceeabfd9d0.png">

The fix I came up with should work for all new users as well as current users who may currently have some orphaned memberships/receipts from users being deleted. Basically, the rows are allowed to exist until we attempt to do something with them.

This is probably the most performant approach, however it could still leave orphaned data in the database. I need to think about that a bit more and decide if I want to add an additional maintenance query to remove them proactively (similar to how I update all step-orphaned memberships [here](https://github.com/honeybadger-io/heya/blob/f8635c0fbcf62129f8a3f09670146daad26c402d/lib/heya/campaigns/scheduler.rb#L17
)).

It occurred to me that we also aren't pruning memberships and receipts if a **campaign** is removed, however after considering I think it's best to leave that to the user—for instance, if you rename a campaign, you need to migrate the receipts/memberships (and wouldn't want them to be automatically deleted). If you delete a campaign but then change your mind later, you'd also potentially want the history to remain intact.