### PR TITLE
Resume campaign immediately when (re-)adding users

### DIFF
--- a/app/models/heya/campaign_membership.rb
+++ b/app/models/heya/campaign_membership.rb
@@ -5,7 +5,7 @@ module Heya
     belongs_to :user, polymorphic: true
 
     before_create do
-      self.last_sent_at = Time.now
+      self.last_sent_at ||= Time.now
     end
 
     scope :with_steps, -> {

--- a/test/lib/heya/campaigns/base_test.rb
+++ b/test/lib/heya/campaigns/base_test.rb
@@ -104,7 +104,7 @@ module Heya
         refute membership.exists?
       end
 
-      test "#add sends first step in campaign by default" do
+      test "#add sends first step in campaign when wait is zero" do
         action = Minitest::Mock.new
         campaign = create_test_campaign {
           default action: action
@@ -121,7 +121,7 @@ module Heya
         assert_mock action
       end
 
-      test "#add skips first step in campaign with send_now: false" do
+      test "#add skips first step in campaign when wait is zero with send_now: false" do
         action = Minitest::Mock.new
         campaign = create_test_campaign {
           default action: action
@@ -180,6 +180,49 @@ module Heya
         contact.update_attribute(:traits, {foo: "bar"})
 
         assert campaign.add(contact)
+      end
+
+      test "#add starts the user on step one when they haven't received the campaign" do
+        campaign = create_test_campaign(name: "Test") {
+          user_type "Contact"
+          step :one
+          step :two
+          step :three
+        }
+
+        campaign.add(contacts(:one))
+
+        membership = CampaignMembership
+          .where(user: contacts(:one), campaign_gid: campaign.gid)
+          .first
+
+        assert_equal campaign.steps[0].gid, membership.step_gid
+      end
+
+      test "#add resumes the campaign where the user left off when they previously received the campaign" do
+        campaign = create_test_campaign(name: "Test") {
+          user_type "Contact"
+          step :one
+          step :two
+          step :three
+        }
+
+        created_at = 2.days.ago
+        CampaignReceipt.create!(
+          user: contacts(:one),
+          step_gid: campaign.steps[0].gid
+        ).tap do |r|
+          r.update(created_at: created_at)
+        end
+
+        campaign.add(contacts(:one))
+
+        membership = CampaignMembership
+          .where(user: contacts(:one), campaign_gid: campaign.gid)
+          .first
+
+        assert_equal campaign.steps[1].gid, membership.step_gid
+        assert_equal created_at, membership.last_sent_at
       end
 
       test "it creates steps with String names" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,7 @@ end
 
 class NullAction
   def initialize(step:, user:)
+    # noop
   end
 
   def deliver_later
@@ -74,6 +75,10 @@ module Heya::Campaigns
 end
 
 class ActiveSupport::TestCase
+  def teardown
+    Timecop.return
+  end
+
   def create_test_campaign(name: "TestCampaign", parent: Heya::Campaigns::Base, action: NullAction, &block)
     klass = Class.new(parent) {
       class << self


### PR DESCRIPTION
Closes #179 (hopefully)

This *does not* add support for evergreen campaigns (I will create a new enhancement issue for that later), but it *should fix* [the bug w/ the current workaround](https://github.com/honeybadger-io/heya/issues/179#issuecomment-1419535513).

The tl;dr version is:

1. When adding a user BACK to a campaign, it will start them on the first message in the campaign that they haven't received yet.
2. From there, they should receive new messages in the campaign in order, skipping any previously received messages.

For more details, see the following comments:

https://github.com/honeybadger-io/heya/issues/179#issuecomment-1185978092
https://github.com/honeybadger-io/heya/issues/179#issuecomment-1185987257

On last thing to note—the wait times are calculated using whatever the current step is, and when someone is re-sent a campaign, it will calculate the time of the next message using the last message they received in the campaign + the wait time of the current step. If they have been out of the campaign for a while, they will most likely receive the next message immediately after being re-added.

I plan to do some manual testing with this branch before merging/releasing. @leemcalilly would you be able to play with this branch to see if it helps with your use case?