### PR TITLE
Fix capitalization in MiniTest

### DIFF
--- a/test/lib/heya/campaigns/actions/block_test.rb
+++ b/test/lib/heya/campaigns/actions/block_test.rb
@@ -7,7 +7,7 @@ module Heya
     module Actions
       class BlockTest < ActiveSupport::TestCase
         test "block actions can be called with one argument" do
-          mock = MiniTest::Mock.new
+          mock = Minitest::Mock.new
           block = proc { |u| mock.call(u) }
           step = OpenStruct.new(params: {"block" => block})
           action = Block.new(user: :user, step: step)
@@ -18,7 +18,7 @@ module Heya
         end
 
         test "block actions can be called with no arguments" do
-          mock = MiniTest::Mock.new
+          mock = Minitest::Mock.new
           block = proc { mock.call }
           step = OpenStruct.new(params: {"block" => block})
           action = Block.new(user: :user, step: step)

--- a/test/lib/heya/campaigns/base_test.rb
+++ b/test/lib/heya/campaigns/base_test.rb
@@ -254,7 +254,7 @@ module Heya
       end
 
       test "executes block actions" do
-        mock = MiniTest::Mock.new
+        mock = Minitest::Mock.new
         campaign = create_test_campaign {
           step :expected_name do |user, step|
             mock.call(user, step.name)


### PR DESCRIPTION
This cased alias has been removed in recent Minitest versions.