### PR TITLE
Fix a Rails startup bug when validating steps that use translations from locale files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix a Rails startup bug when validating steps that use translations from locale
+  files. (#211)
 
 ## [0.8.0] - 2023-03-28
 ### Added

--- a/lib/heya/engine.rb
+++ b/lib/heya/engine.rb
@@ -11,6 +11,18 @@ module Heya
     end
 
     config.to_prepare do
+      # This runs the first time *before* Rails is initialized. Because
+      # campaigns depend on Rails initialization, we use the `after_initialize`
+      # hook when Rails first starts up, and then `to_prepare` when reloading
+      # in development. See https://github.com/honeybadger-io/heya/issues/211
+      if ::Rails.application.initialized?
+        Dir.glob(Rails.root + "app/campaigns/*.rb").each do |c|
+          require_dependency(c)
+        end
+      end
+    end
+
+    config.after_initialize do
       Dir.glob(Rails.root + "app/campaigns/*.rb").each do |c|
         require_dependency(c)
       end


### PR DESCRIPTION
I have tested this locally with Rails 7.0, and it seems to work there, at least. I want to be sure I'm not introducing a new autoloading bug, however.

Fixes #211 