### PR TITLE
Add lambda support for from, bcc, and reply_to campaign options

### DIFF
--- a/app/mailers/heya/campaign_mailer.rb
+++ b/app/mailers/heya/campaign_mailer.rb
@@ -12,8 +12,13 @@ module Heya
       step_name = step.name.underscore
 
       from = step.params.fetch("from")
+      from = from.call(user) if from.respond_to?(:call)
+
       bcc = step.params.fetch("bcc", nil)
+      bcc = bcc.call(user) if bcc.respond_to?(:call)
+
       reply_to = step.params.fetch("reply_to", nil)
+      reply_to = reply_to.call(user) if reply_to.respond_to?(:call)
 
       subject = step.params.fetch("subject") {
         I18n.t("#{campaign_name}.#{step_name}.subject", **attributes_for(user))


### PR DESCRIPTION
Adds support for lambdas in the `from`, `bcc`, and `reply_to` email options. Currently only the `to` field support dynamic addressing.

Use case: I needed to support sending from dynamic email addresses for whitelabeling.

```ruby
step :support,
  from: ->(user){user.account.brand_support_email.presence || "noreply@example.com"}
```