### PR TITLE
Fix typo in html message template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix a typo in message.html.erb.tt.
 
 ## [0.10.0] - 2024-03-18
 ### Added
@@ -13,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix a Rails startup bug when validating steps that use translations from locale
   files. (#211)
-- Fix a typo in message.html.erb.tt.
 
 ## [0.9.0] - 2023-10-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix a Rails startup bug when validating steps that use translations from locale
   files. (#211)
+- Fix a typo in message.html.erb.tt.
 
 ## [0.9.0] - 2023-10-06
 ### Added

--- a/lib/generators/heya/campaign/templates/message.html.erb.tt
+++ b/lib/generators/heya/campaign/templates/message.html.erb.tt
@@ -1,1 +1,1 @@
-This is the <%= @step.downcase %> messsage.
+This is the <%= @step.downcase %> message.


### PR DESCRIPTION
**This PR:**
- Fixes a typo in `message.html.erb.tt`