### PR TITLE
Add to README: How to extend Campaign Mailers

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,23 @@ See the
 [Rails documentation](https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from)
 for additional details.
 
+### Extending Campaign Mailers with Macros
+
+The campaign generator does not create a Mailer class for campaigns. In order to enhance a campaign
+with a macro from another gem (such as for adding analytics), you can do so by extending the
+`Heya::ApplicationMailer` class.
+
+- Create a new file at `app/mailers/heya/application_mailer.rb`
+- Add the following to it:
+
+```
+module Heya
+  class ApplicationMailer < ActionMailer::Base
+    macro_to_add_to_all_campaign_mailers
+  end
+end
+```
+
 ### Campaigns FAQ
 **What happens when:**
 <details><summary>I reorder messages in an active campaign?</summary>


### PR DESCRIPTION
**This PR:**
- Adds a section to the README. It explains how to add a macro from another gem to all campaign mailers since the Heya campaign generator does not create a `Mailer` class for a campaign.

Would it be helpful to give an example for a specific gem (in my case, analytics through Ahoy Email), or is it better to be more generic like this?