### PR TITLE
Skip views and preview flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `--skip-previews` and `--skip-views` flags to skip mail previews and views (#276, @HenriqueMorato)
+
 ## [0.11.0] - 2024-09-16
 ### Added
 - Support Rails 7.2 (#270, @jbennett)

--- a/lib/generators/heya/campaign/campaign_generator.rb
+++ b/lib/generators/heya/campaign/campaign_generator.rb
@@ -4,6 +4,8 @@ class Heya::CampaignGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
 
   argument :steps, type: :array, default: []
+  class_option :skip_previews, type: :boolean, default: false
+  class_option :skip_views, type: :boolean, default: false
 
   def copy_campaign_template
     application_campaign = "app/campaigns/application_campaign.rb"
@@ -14,6 +16,8 @@ class Heya::CampaignGenerator < Rails::Generators::NamedBase
   end
 
   def copy_view_templates
+    return if skip_views?
+
     selection =
       if defined?(Maildown)
         puts <<~MSG
@@ -45,6 +49,8 @@ class Heya::CampaignGenerator < Rails::Generators::NamedBase
   end
 
   def copy_test_templates
+    return if skip_previews?
+
     if preview_path
       template "preview.rb", preview_path.join("#{file_name.underscore}_campaign_preview.rb")
     end
@@ -73,5 +79,13 @@ class Heya::CampaignGenerator < Rails::Generators::NamedBase
 
       Pathname(preview_path).sub(Rails.root.to_s, ".") if preview_path
     end
+  end
+
+  def skip_previews?
+    options[:skip_previews]
+  end
+
+  def skip_views?
+    options[:skip_views]
   end
 end

--- a/test/lib/generators/heya/heya/campaign_generator_test.rb
+++ b/test/lib/generators/heya/heya/campaign_generator_test.rb
@@ -11,8 +11,26 @@ module Heya
 
     test "generator runs without errors" do
       assert_nothing_raised do
-        run_generator ["arguments"]
+        run_generator %w[arguments welcome:0]
       end
+      assert_file "test/mailers/previews/arguments_campaign_preview.rb"
+      assert_file "app/views/heya/campaign_mailer/arguments_campaign/welcome.html.erb"
+      assert_file "app/views/heya/campaign_mailer/arguments_campaign/welcome.text.erb"
+    end
+
+    test "supports flag --skip-previews" do
+      assert_nothing_raised do
+        run_generator %w[arguments --skip-previews]
+      end
+      assert_no_file "test/mailers/previews/arguments_campaign_preview.rb"
+    end
+
+    test "supports flag --skip-views" do
+      assert_nothing_raised do
+        run_generator %w[arguments welcome:0 --skip-views]
+      end
+      assert_no_file "app/views/heya/campaign_mailer/arguments_campaign/welcome.html.erb"
+      assert_no_file "app/views/heya/campaign_mailer/arguments_campaign/welcome.text.erb"
     end
   end
 end


### PR DESCRIPTION
You may want to use heya campaign intelligence but customize the way you send mailers at the end of a step block, so you don't need views or previews